### PR TITLE
Add getPets endpoint to petRouter

### DIFF
--- a/src/schema/getPetsRequest.ts
+++ b/src/schema/getPetsRequest.ts
@@ -1,0 +1,7 @@
+import {z} from "zod";
+
+export const getPetsRequest = z.object({
+    userId: z.string(),
+});
+
+export type GetPetsRequest = z.infer<typeof getPetsRequest>;

--- a/src/server/api/routers/pet.ts
+++ b/src/server/api/routers/pet.ts
@@ -2,6 +2,8 @@ import {createTRPCRouter, publicProcedure} from "~/server/api/trpc";
 import {db} from "~/server/db";
 import {createPetRequestInput} from "~/schema/createPetRequestInput";
 import {PetPeople, Pets} from "~/server/db/schema";
+import {getPetsRequest} from "~/schema/getPetsRequest";
+import {eq} from "drizzle-orm/expressions";
 
 export const petRouter = createTRPCRouter({
     insertPet: publicProcedure
@@ -41,4 +43,15 @@ export const petRouter = createTRPCRouter({
                 return newPet;
             });
         }),
+    // TODO: update to enforce the userId is equal to the logged in user
+    getPets: publicProcedure
+        .input(getPetsRequest)
+        .query(async ({input}) => {
+            const { userId } = input;
+            return await db.select()
+                .from(Pets)
+                .innerJoin(PetPeople, eq(Pets.PetID, PetPeople.PetID))
+                .where(eq(PetPeople.UserID, userId))
+                .execute()
+            }),
 });


### PR DESCRIPTION
Implemented a new endpoint to retrieve pets associated with a user. Introduced `getPetsRequest` schema to validate the request input.