### PR TITLE
Phase 0: stabilize tRPC API (auth, ownership, bug fixes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "db:studio": "drizzle-kit studio",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/nextjs": "^5.1.5",

--- a/src/schema/createPetRequestInput.ts
+++ b/src/schema/createPetRequestInput.ts
@@ -5,7 +5,6 @@ export const createPetRequestInput = z.object({
     gender: z.string(),
     name: z.string(),
     age: z.number(),
-    userId: z.string()
 })
 
 export type CreatePetRequestInput = z.infer<typeof createPetRequestInput>;

--- a/src/schema/getPetsRequest.ts
+++ b/src/schema/getPetsRequest.ts
@@ -1,7 +1,0 @@
-import {z} from "zod";
-
-export const getPetsRequest = z.object({
-    userId: z.string(),
-});
-
-export type GetPetsRequest = z.infer<typeof getPetsRequest>;

--- a/src/server/api/petAccess.ts
+++ b/src/server/api/petAccess.ts
@@ -1,0 +1,30 @@
+import { TRPCError } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
+
+import { type db } from "~/server/db";
+import { PetPeople } from "~/server/db/schema";
+
+/**
+ * Throws FORBIDDEN if the user does not have a row in PetPeople for the given pet.
+ * Returns the user's role on success in case callers want to gate writes on it.
+ */
+export async function assertPetAccess(
+  database: typeof db,
+  userId: string,
+  petId: number,
+) {
+  const rows = await database
+    .select({ role: PetPeople.Role })
+    .from(PetPeople)
+    .where(and(eq(PetPeople.PetID, petId), eq(PetPeople.UserID, userId)))
+    .limit(1);
+
+  const access = rows[0];
+  if (!access) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You do not have access to this pet.",
+    });
+  }
+  return access.role;
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,5 +1,7 @@
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 import { petRouter } from "~/server/api/routers/pet";
+import { weightRouter } from "~/server/api/routers/weight";
+import { feedingRouter } from "~/server/api/routers/feeding";
 
 /**
  * This is the primary router for your server.
@@ -8,6 +10,8 @@ import { petRouter } from "~/server/api/routers/pet";
  */
 export const appRouter = createTRPCRouter({
   pet: petRouter,
+  weight: weightRouter,
+  feeding: feedingRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/feeding.ts
+++ b/src/server/api/routers/feeding.ts
@@ -1,22 +1,24 @@
-import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
-import { db } from "~/server/db";
+import { asc, eq } from "drizzle-orm";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { EatingHistory } from "~/server/db/schema";
 import { getFeedingHistoryInput } from "~/schema/getFeedingHistoryInput";
 import { recordFeedingInput } from "~/schema/recordFeedingInput";
+import { assertPetAccess } from "~/server/api/petAccess";
 
 export const feedingRouter = createTRPCRouter({
-    // Endpoint to record a pet's feeding
-    recordFeeding: publicProcedure
+    recordFeeding: protectedProcedure
         .input(recordFeedingInput)
-        .mutation(async ({ input }) => {
+        .mutation(async ({ ctx, input }) => {
             const { petId, foodId, quantity, fedAt } = input;
+            await assertPetAccess(ctx.db, ctx.userId, petId);
 
-            const newFeedingEntry = await db.insert(EatingHistory).values({
+            const [newFeedingEntry] = await ctx.db.insert(EatingHistory).values({
                 PetID: petId,
                 FoodID: foodId,
                 Quantity: quantity,
-                CreatedAtUTC: new Date(), // When the record was created
-                FedAtUTC: fedAt ?? new Date(), // When the feeding occurred
+                CreatedAtUTC: new Date(),
+                FedAtUTC: fedAt ?? new Date(),
             }).returning({
                 EntryID: EatingHistory.EntryID,
                 PetID: EatingHistory.PetID,
@@ -33,22 +35,15 @@ export const feedingRouter = createTRPCRouter({
             return newFeedingEntry;
         }),
 
-    // Endpoint to get feeding history for a pet
-    getFeedingHistory: publicProcedure
+    getFeedingHistory: protectedProcedure
         .input(getFeedingHistoryInput)
-        .query(async ({ input }) => {
+        .query(async ({ ctx, input }) => {
             const { petId } = input;
+            await assertPetAccess(ctx.db, ctx.userId, petId);
 
-            const feedingHistory = await db.select()
+            return ctx.db.select()
                 .from(EatingHistory)
-                .where(EatingHistory.PetID === petId)
-                .orderBy(EatingHistory.FedAtUTC.asc())
-                .execute();
-
-            if (!feedingHistory) {
-                throw new Error("Failed to fetch feeding history or no records found.");
-            }
-
-            return feedingHistory;
+                .where(eq(EatingHistory.PetID, petId))
+                .orderBy(asc(EatingHistory.FedAtUTC));
         }),
 });

--- a/src/server/api/routers/pet.ts
+++ b/src/server/api/routers/pet.ts
@@ -1,17 +1,17 @@
-import {createTRPCRouter, publicProcedure} from "~/server/api/trpc";
-import {db} from "~/server/db";
-import {createPetRequestInput} from "~/schema/createPetRequestInput";
-import {PetPeople, Pets} from "~/server/db/schema";
-import {getPetsRequest} from "~/schema/getPetsRequest";
-import {eq} from "drizzle-orm/expressions";
+import { eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { createPetRequestInput } from "~/schema/createPetRequestInput";
+import { PetPeople, Pets } from "~/server/db/schema";
 
 export const petRouter = createTRPCRouter({
-    insertPet: publicProcedure
+    insertPet: protectedProcedure
         .input(createPetRequestInput)
-        .mutation(async ({input}) => {
-            const {species, gender, name, age, userId} = input;
+        .mutation(async ({ ctx, input }) => {
+            const { species, gender, name, age } = input;
 
-            return await db.transaction(async (trx) => {
+            return await ctx.db.transaction(async (trx) => {
                 const [newPet] = await trx.insert(Pets).values({
                     Species: species,
                     Gender: gender,
@@ -23,35 +23,32 @@ export const petRouter = createTRPCRouter({
                     Gender: Pets.Gender,
                     Name: Pets.Name,
                     Age: Pets.Age,
-                })
+                });
 
                 if (!newPet) {
-                    trx.rollback()
-                    // TODO : make error more informative
-                    throw new Error("Failed to create the pet entry")
+                    throw new TRPCError({
+                        code: "INTERNAL_SERVER_ERROR",
+                        message: "Failed to create the pet entry",
+                    });
                 }
 
-
                 await trx.insert(PetPeople).values({
-                    UserID: userId,
+                    UserID: ctx.userId,
                     PetID: newPet.PetID,
                     CreatedAt: new Date(),
                     UpdatedAt: new Date(),
-                    Role: 'Owner'
+                    Role: "Owner",
                 });
 
                 return newPet;
             });
         }),
-    // TODO: update to enforce the userId is equal to the logged in user
-    getPets: publicProcedure
-        .input(getPetsRequest)
-        .query(async ({input}) => {
-            const { userId } = input;
-            return await db.select()
+
+    getPets: protectedProcedure
+        .query(async ({ ctx }) => {
+            return ctx.db.select()
                 .from(Pets)
                 .innerJoin(PetPeople, eq(Pets.PetID, PetPeople.PetID))
-                .where(eq(PetPeople.UserID, userId))
-                .execute()
-            }),
+                .where(eq(PetPeople.UserID, ctx.userId));
+        }),
 });

--- a/src/server/api/routers/weight.ts
+++ b/src/server/api/routers/weight.ts
@@ -1,22 +1,23 @@
-import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
-import { db } from "~/server/db";
+import { asc, eq } from "drizzle-orm";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { WeightHistory } from "~/server/db/schema";
 import { getWeightHistoryInput } from "~/schema/getPetWeightInput";
 import { recordWeightInput } from "~/schema/recordPetWeightInput";
-
+import { assertPetAccess } from "~/server/api/petAccess";
 
 export const weightRouter = createTRPCRouter({
-    // Endpoint to record a pet's weight
-    recordWeight: publicProcedure
+    recordWeight: protectedProcedure
         .input(recordWeightInput)
-        .mutation(async ({ input }) => {
+        .mutation(async ({ ctx, input }) => {
             const { petId, weight, recordedAt } = input;
+            await assertPetAccess(ctx.db, ctx.userId, petId);
 
-            const newWeightEntry = await db.insert(WeightHistory).values({
+            const [newWeightEntry] = await ctx.db.insert(WeightHistory).values({
                 PetID: petId,
                 Weight: weight,
-                CreatedUTC: new Date(), // When the record was created
-                WeightedUTC: recordedAt ?? new Date(), // When the weight was recorded
+                CreatedUTC: new Date(),
+                WeightedUTC: recordedAt ?? new Date(),
             }).returning({
                 RecordID: WeightHistory.RecordID,
                 PetID: WeightHistory.PetID,
@@ -32,22 +33,15 @@ export const weightRouter = createTRPCRouter({
             return newWeightEntry;
         }),
 
-    // Endpoint to get weight history for a pet
-    getWeightHistory: publicProcedure
+    getWeightHistory: protectedProcedure
         .input(getWeightHistoryInput)
-        .query(async ({ input }) => {
+        .query(async ({ ctx, input }) => {
             const { petId } = input;
+            await assertPetAccess(ctx.db, ctx.userId, petId);
 
-            const weightHistory = await db.select()
+            return ctx.db.select()
                 .from(WeightHistory)
-                .where(WeightHistory.PetID === petId)
-                .orderBy(WeightHistory.WeightedUTC.asc())
-                .execute();
-
-            if (!weightHistory) {
-                throw new Error("Failed to fetch weight history or no records found.");
-            }
-
-            return weightHistory;
+                .where(eq(WeightHistory.PetID, petId))
+                .orderBy(asc(WeightHistory.WeightedUTC));
         }),
 });

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -6,11 +6,13 @@
  * TL;DR - This is where all the tRPC server stuff is created and plugged in. The pieces you will
  * need to use are documented accordingly near the end.
  */
-import { initTRPC } from "@trpc/server";
+import { auth } from "@clerk/nextjs/server";
+import { TRPCError, initTRPC } from "@trpc/server";
 import superjson from "superjson";
 import { ZodError } from "zod";
 
 import { db } from "~/server/db";
+import { Users } from "~/server/db/schema";
 
 /**
  * 1. CONTEXT
@@ -25,8 +27,10 @@ import { db } from "~/server/db";
  * @see https://trpc.io/docs/server/context
  */
 export const createTRPCContext = async (opts: { headers: Headers }) => {
+  const { userId } = auth();
   return {
     db,
+    userId,
     ...opts,
   };
 };
@@ -81,3 +85,26 @@ export const createTRPCRouter = t.router;
  * are logged in.
  */
 export const publicProcedure = t.procedure;
+
+/**
+ * Protected (authenticated) procedure.
+ *
+ * Requires a signed-in Clerk user. Lazily upserts the user into our `Users` table on first call so
+ * downstream foreign keys (e.g. `PetPeople.UserID`) are always valid without needing a separate
+ * Clerk webhook.
+ */
+const enforceUserIsAuthed = t.middleware(async ({ ctx, next }) => {
+  if (!ctx.userId) {
+    throw new TRPCError({ code: "UNAUTHORIZED" });
+  }
+
+  const now = new Date();
+  await ctx.db
+    .insert(Users)
+    .values({ UserID: ctx.userId, CreatedAt: now, UpdatedAt: now })
+    .onConflictDoNothing();
+
+  return next({ ctx: { ...ctx, userId: ctx.userId } });
+});
+
+export const protectedProcedure = t.procedure.use(enforceUserIsAuthed);


### PR DESCRIPTION
## Summary

Phase 0 of picking the project back up — get the API to a stable, secure baseline before building UI on top of it. No new features.

### Bugs fixed
- **`weight` and `feeding` routers were never registered** in `src/server/api/root.ts`, so every endpoint in those files (PRs #10/#11) was unreachable. Mounted both.
- **`where(Column === value)` is a JavaScript boolean, not a Drizzle expression.** Both `getWeightHistory` and `getFeedingHistory` were effectively returning unfiltered rows. Replaced with `eq()`.
- **`Column.asc()` doesn't exist in Drizzle.** Replaced with `asc(Column)` imported from `drizzle-orm`.

### Authorization
- Added `protectedProcedure`: pulls `userId` from Clerk's `auth()` via the tRPC context and throws `UNAUTHORIZED` if missing.
- Moved every existing procedure (`pet.insertPet`, `pet.getPets`, `weight.*`, `feeding.*`) onto `protectedProcedure`.
- Dropped `userId` from `createPetRequestInput` and `getPetsRequest` — `userId` is now session-derived, not caller-supplied. Previously any caller could create or list pets for any user ID.
- Added `assertPetAccess(db, userId, petId)` helper. `weight` and `feeding` endpoints now verify the caller has a `PetPeople` row for the target pet (any role) and return `FORBIDDEN` otherwise.

### User row sync
- The `Users` table is referenced by `PetPeople.UserID` but nothing was populating it. Added a lazy `INSERT … ON CONFLICT DO NOTHING` inside `protectedProcedure` so the row exists by the time any FK insert runs. This avoids a Clerk webhook (and its env/setup overhead) for now — easy to swap later if we want richer user metadata.

### Tooling
- Added `pnpm typecheck` (`tsc --noEmit`).

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (only pre-existing warnings on `app/page.tsx` remain)
- [ ] Manually exercise on a deploy preview: sign in, create a pet, log a weight, log a feeding, fetch history
- [ ] Confirm a second user cannot read or write the first user's pet (FORBIDDEN)

## Out of scope (next phases)
- Schema cleanup (snake_case, `timestamptz`, `birth_date` instead of `Age`, drop `EatingHistory.Date`)
- Replace lazy user upsert with a Clerk webhook
- Pet-detail authorization helper for any future per-record endpoints
- UI (`/dashboard`, add-pet form, quick-log, weight chart) — Phase 1

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_