### PR TITLE
S8: today's feedings list + daily kcal total

### DIFF
--- a/drizzle/0001_broad_amphibian.sql
+++ b/drizzle/0001_broad_amphibian.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "meow-weight-tracker_pets" ADD COLUMN "deleted_at" timestamp with time zone;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,447 @@
+{
+  "id": "a5c4fa2d-ce28-401f-bea9-272cf6f14bb1",
+  "prevId": "9d3c8a52-aedd-4ca7-bf24-e8d8dedc2b59",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.meow-weight-tracker_eating_history": {
+      "name": "meow-weight-tracker_eating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fed_at": {
+          "name": "fed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_grams": {
+          "name": "quantity_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eating_history_pet_id_idx": {
+          "name": "eating_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk": {
+          "name": "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pet_food",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_food": {
+      "name": "meow-weight-tracker_pet_food",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories_per_gram": {
+          "name": "calories_per_gram",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_percent": {
+          "name": "protein_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat_percent": {
+          "name": "fat_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs_percent": {
+          "name": "carbs_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_food_name_idx": {
+          "name": "pet_food_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_people": {
+      "name": "meow-weight-tracker_pet_people",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_people_user_id_idx": {
+          "name": "pet_people_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "pet_people_pet_id_idx": {
+          "name": "pet_people_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meow-weight-tracker_pet_people_user_id_pet_id_pk": {
+          "name": "meow-weight-tracker_pet_people_user_id_pet_id_pk",
+          "columns": [
+            "user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pets": {
+      "name": "meow-weight-tracker_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_users": {
+      "name": "meow-weight-tracker_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_weight_history": {
+      "name": "meow-weight-tracker_weight_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weighed_at": {
+          "name": "weighed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weight_history_pet_id_idx": {
+          "name": "weight_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_weight_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.pet_role": {
+      "name": "pet_role",
+      "schema": "public",
+      "values": [
+        "Owner",
+        "Editor",
+        "Viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1778701274530,
       "tag": "0000_wide_doctor_octopus",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1778702469759,
+      "tag": "0001_broad_amphibian",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "recharts": "^3.8.1",
     "server-only": "^0.0.1",
     "superjson": "^2.2.1",
+    "svix": "^1.93.0",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       superjson:
         specifier: ^2.2.1
         version: 2.2.1
+      svix:
+        specifier: ^1.93.0
+        version: 1.93.0
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -930,6 +933,9 @@ packages:
 
   '@rushstack/eslint-patch@1.10.3':
     resolution: {integrity: sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1801,6 +1807,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -2734,6 +2743,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
 
@@ -2809,6 +2821,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.93.0:
+    resolution: {integrity: sha512-AeCcSs+CrHNejZytBuvD4hw2B14rB7+Sq7ggwYgF22TgXh0uJJ3T4uVJSbSYKFSbO1AA4o470XoGgOYqu2fbSA==}
 
   swr@2.2.5:
     resolution: {integrity: sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==}
@@ -3640,6 +3655,8 @@ snapshots:
       react-redux: 9.2.0(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1)
 
   '@rushstack/eslint-patch@1.10.3': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4689,6 +4706,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fastq@1.17.1:
     dependencies:
       reusify: 1.0.4
@@ -5573,6 +5592,11 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@3.7.0: {}
 
   streamsearch@1.1.0: {}
@@ -5659,6 +5683,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.93.0:
+    dependencies:
+      standardwebhooks: 1.0.0
 
   swr@2.2.5(react@18.3.1):
     dependencies:

--- a/src/app/api/clerk/webhook/route.ts
+++ b/src/app/api/clerk/webhook/route.ts
@@ -1,0 +1,61 @@
+import { headers } from "next/headers";
+import { eq } from "drizzle-orm";
+import { Webhook } from "svix";
+
+import { env } from "~/env";
+import { db } from "~/server/db";
+import { users } from "~/server/db/schema";
+
+type ClerkEvent = {
+    type: string;
+    data: { id: string };
+};
+
+export async function POST(req: Request) {
+    if (!env.CLERK_WEBHOOK_SECRET) {
+        return new Response("CLERK_WEBHOOK_SECRET not configured", {
+            status: 500,
+        });
+    }
+
+    const h = headers();
+    const svixId = h.get("svix-id");
+    const svixTimestamp = h.get("svix-timestamp");
+    const svixSignature = h.get("svix-signature");
+    if (!svixId || !svixTimestamp || !svixSignature) {
+        return new Response("Missing svix headers", { status: 400 });
+    }
+
+    const body = await req.text();
+    const wh = new Webhook(env.CLERK_WEBHOOK_SECRET);
+    let event: ClerkEvent;
+    try {
+        event = wh.verify(body, {
+            "svix-id": svixId,
+            "svix-timestamp": svixTimestamp,
+            "svix-signature": svixSignature,
+        }) as ClerkEvent;
+    } catch {
+        return new Response("Signature verification failed", { status: 400 });
+    }
+
+    switch (event.type) {
+        case "user.created":
+            await db
+                .insert(users)
+                .values({ id: event.data.id })
+                .onConflictDoNothing();
+            break;
+        case "user.updated":
+            await db
+                .update(users)
+                .set({ updatedAt: new Date() })
+                .where(eq(users.id, event.data.id));
+            break;
+        // user.deleted: leave the row to preserve petPeople FK integrity.
+        default:
+            break;
+    }
+
+    return new Response("OK", { status: 200 });
+}

--- a/src/app/dashboard/_components/dashboard-content.tsx
+++ b/src/app/dashboard/_components/dashboard-content.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { PetPicker } from "~/app/dashboard/_components/pet-picker";
 import { RecordFeedingDialog } from "~/app/dashboard/_components/record-feeding-dialog";
 import { RecordWeightDialog } from "~/app/dashboard/_components/record-weight-dialog";
+import { TodayFeedings } from "~/app/dashboard/_components/today-feedings";
 import { WeightChart } from "~/app/dashboard/_components/weight-chart";
 import { type RouterOutputs } from "~/trpc/react";
 
@@ -25,6 +26,7 @@ export function DashboardContent({ pets }: { pets: Pet[] }) {
                 <RecordWeightDialog pet={selectedPet} />
                 <RecordFeedingDialog pet={selectedPet} />
             </div>
+            <TodayFeedings petId={selectedPet.id} petName={selectedPet.name} />
             <WeightChart petId={selectedPet.id} petName={selectedPet.name} />
         </div>
     );

--- a/src/app/dashboard/_components/dashboard-content.tsx
+++ b/src/app/dashboard/_components/dashboard-content.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
+import { ChevronRight } from "lucide-react";
 
+import { Button } from "~/components/ui/button";
 import { PetPicker } from "~/app/dashboard/_components/pet-picker";
 import { RecordFeedingDialog } from "~/app/dashboard/_components/record-feeding-dialog";
 import { RecordWeightDialog } from "~/app/dashboard/_components/record-weight-dialog";
@@ -22,6 +25,14 @@ export function DashboardContent({ pets }: { pets: Pet[] }) {
                 selectedId={selectedPet.id}
                 onSelect={setSelectedId}
             />
+            <div className="flex justify-end">
+                <Button asChild variant="ghost" size="sm">
+                    <Link href={`/dashboard/pets/${selectedPet.id}`}>
+                        {selectedPet.name}&apos;s details
+                        <ChevronRight className="ml-1 h-4 w-4" />
+                    </Link>
+                </Button>
+            </div>
             <div className="grid gap-4 sm:grid-cols-2">
                 <RecordWeightDialog pet={selectedPet} />
                 <RecordFeedingDialog pet={selectedPet} />

--- a/src/app/dashboard/_components/today-feedings.tsx
+++ b/src/app/dashboard/_components/today-feedings.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useMemo } from "react";
+
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { api } from "~/trpc/react";
+
+export function TodayFeedings({
+    petId,
+    petName,
+}: {
+    petId: number;
+    petName: string;
+}) {
+    const { data, isLoading } = api.feeding.getFeedingHistory.useQuery({
+        petId,
+    });
+
+    const today = useMemo(() => {
+        if (!data) return [];
+        const start = new Date();
+        start.setHours(0, 0, 0, 0);
+        const end = new Date(start);
+        end.setDate(end.getDate() + 1);
+        return data.filter((row) => {
+            const t = row.fedAt.getTime();
+            return t >= start.getTime() && t < end.getTime();
+        });
+    }, [data]);
+
+    const totalKcal = today.reduce(
+        (sum, row) => sum + row.quantityGrams * row.food.caloriesPerGram,
+        0,
+    );
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                <div>
+                    <CardTitle>Today&apos;s feedings</CardTitle>
+                    <CardDescription>
+                        {petName} · {today.length}{" "}
+                        {today.length === 1 ? "feeding" : "feedings"}
+                    </CardDescription>
+                </div>
+                <div className="text-right">
+                    <div className="text-2xl font-semibold">
+                        {totalKcal.toFixed(0)}
+                    </div>
+                    <div className="text-xs text-muted-foreground">kcal today</div>
+                </div>
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <p className="text-sm text-muted-foreground">Loading…</p>
+                ) : today.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        No feedings logged today yet.
+                    </p>
+                ) : (
+                    <ul className="space-y-2">
+                        {today.map((row) => {
+                            const kcal = row.quantityGrams * row.food.caloriesPerGram;
+                            return (
+                                <li
+                                    key={row.id}
+                                    className="flex items-center justify-between rounded-md border px-3 py-2 text-sm"
+                                >
+                                    <div>
+                                        <div className="font-medium">
+                                            {row.food.brand
+                                                ? `${row.food.brand} — ${row.food.name}`
+                                                : row.food.name}
+                                        </div>
+                                        <div className="text-xs text-muted-foreground">
+                                            {row.fedAt.toLocaleTimeString([], {
+                                                hour: "numeric",
+                                                minute: "2-digit",
+                                            })}{" "}
+                                            · {row.quantityGrams} g
+                                        </div>
+                                    </div>
+                                    <div className="text-sm font-medium">
+                                        {kcal.toFixed(0)} kcal
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/pets/[id]/_components/delete-pet-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/delete-pet-card.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "~/components/ui/dialog";
+import { api } from "~/trpc/react";
+
+export function DeletePetCard({
+    petId,
+    petName,
+    role,
+}: {
+    petId: number;
+    petName: string;
+    role: "Owner" | "Editor" | "Viewer";
+}) {
+    const router = useRouter();
+    const [open, setOpen] = useState(false);
+    const utils = api.useUtils();
+
+    const deletePet = api.pet.deletePet.useMutation({
+        onSuccess: async () => {
+            await utils.pet.getPets.invalidate();
+            router.push("/dashboard");
+            router.refresh();
+        },
+    });
+
+    if (role !== "Owner") return null;
+
+    return (
+        <Card className="border-destructive/40">
+            <CardHeader>
+                <CardTitle className="text-destructive">Danger zone</CardTitle>
+                <CardDescription>
+                    Deleting hides {petName} and their history from the dashboard. The
+                    data is kept and can be restored by a maintainer.
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                <Dialog open={open} onOpenChange={setOpen}>
+                    <Button
+                        type="button"
+                        variant="destructive"
+                        onClick={() => setOpen(true)}
+                    >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Delete {petName}
+                    </Button>
+                    <DialogContent>
+                        <DialogHeader>
+                            <DialogTitle>Delete {petName}?</DialogTitle>
+                            <DialogDescription>
+                                This hides {petName} and all related weight and feeding
+                                history from your dashboard. The records are soft-deleted
+                                and recoverable by a maintainer.
+                            </DialogDescription>
+                        </DialogHeader>
+                        {deletePet.error && (
+                            <p className="text-sm text-destructive">
+                                {deletePet.error.message}
+                            </p>
+                        )}
+                        <DialogFooter>
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => setOpen(false)}
+                                disabled={deletePet.isPending}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                type="button"
+                                variant="destructive"
+                                onClick={() => deletePet.mutate({ petId })}
+                                disabled={deletePet.isPending}
+                            >
+                                {deletePet.isPending ? "Deleting…" : "Delete"}
+                            </Button>
+                        </DialogFooter>
+                    </DialogContent>
+                </Dialog>
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/pets/[id]/_components/feeding-history-list.tsx
+++ b/src/app/dashboard/pets/[id]/_components/feeding-history-list.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useMemo } from "react";
+
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { api } from "~/trpc/react";
+import { type RouterOutputs } from "~/trpc/react";
+
+type Feeding = RouterOutputs["feeding"]["getFeedingHistory"][number];
+
+export function FeedingHistoryList({ petId }: { petId: number }) {
+    const { data, isLoading } = api.feeding.getFeedingHistory.useQuery({
+        petId,
+    });
+
+    const grouped = useMemo(() => groupByDay(data ?? []), [data]);
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Feeding history</CardTitle>
+                <CardDescription>
+                    All recorded feedings, grouped by day.
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <p className="text-sm text-muted-foreground">Loading…</p>
+                ) : grouped.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        No feedings recorded yet.
+                    </p>
+                ) : (
+                    <div className="space-y-5">
+                        {grouped.map(({ dayKey, dayLabel, items, totalKcal }) => (
+                            <div key={dayKey} className="space-y-1">
+                                <div className="flex items-baseline justify-between border-b pb-1">
+                                    <div className="text-sm font-medium">
+                                        {dayLabel}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                        {totalKcal.toFixed(0)} kcal · {items.length}{" "}
+                                        {items.length === 1 ? "feeding" : "feedings"}
+                                    </div>
+                                </div>
+                                <ul className="divide-y">
+                                    {items.map((row) => {
+                                        const kcal =
+                                            row.quantityGrams * row.food.caloriesPerGram;
+                                        return (
+                                            <li
+                                                key={row.id}
+                                                className="flex items-center justify-between py-2 text-sm"
+                                            >
+                                                <div>
+                                                    <div className="font-medium">
+                                                        {row.food.brand
+                                                            ? `${row.food.brand} — ${row.food.name}`
+                                                            : row.food.name}
+                                                    </div>
+                                                    <div className="text-xs text-muted-foreground">
+                                                        {row.fedAt.toLocaleTimeString([], {
+                                                            hour: "numeric",
+                                                            minute: "2-digit",
+                                                        })}{" "}
+                                                        · {row.quantityGrams} g
+                                                    </div>
+                                                </div>
+                                                <div>{kcal.toFixed(0)} kcal</div>
+                                            </li>
+                                        );
+                                    })}
+                                </ul>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+function groupByDay(rows: Feeding[]) {
+    const map = new Map<
+        string,
+        { dayKey: string; dayLabel: string; items: Feeding[]; totalKcal: number }
+    >();
+    for (const row of rows) {
+        const d = row.fedAt;
+        const dayKey = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+        const dayLabel = d.toLocaleDateString(undefined, {
+            weekday: "short",
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+        });
+        let bucket = map.get(dayKey);
+        if (!bucket) {
+            bucket = { dayKey, dayLabel, items: [], totalKcal: 0 };
+            map.set(dayKey, bucket);
+        }
+        bucket.items.push(row);
+        bucket.totalKcal += row.quantityGrams * row.food.caloriesPerGram;
+    }
+    return [...map.values()];
+}

--- a/src/app/dashboard/pets/[id]/_components/pet-edit-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/pet-edit-card.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Pencil } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { api } from "~/trpc/react";
+import { type RouterOutputs } from "~/trpc/react";
+
+type Pet = RouterOutputs["pet"]["getPet"];
+
+export function PetEditCard({ pet }: { pet: Pet }) {
+    const [editing, setEditing] = useState(false);
+    const [name, setName] = useState(pet.name);
+    const [species, setSpecies] = useState(pet.species);
+    const [gender, setGender] = useState(pet.gender);
+    const [birthDate, setBirthDate] = useState(pet.birthDate ?? "");
+
+    const utils = api.useUtils();
+    const updatePet = api.pet.updatePet.useMutation({
+        onSuccess: async () => {
+            await Promise.all([
+                utils.pet.getPet.invalidate({ petId: pet.id }),
+                utils.pet.getPets.invalidate(),
+            ]);
+            setEditing(false);
+        },
+    });
+
+    function onSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        updatePet.mutate({
+            petId: pet.id,
+            name: name.trim(),
+            species: species.trim(),
+            gender: gender.trim(),
+            birthDate: birthDate ? birthDate : null,
+        });
+    }
+
+    const canEdit = pet.role !== "Viewer";
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                <div>
+                    <CardTitle>{pet.name}</CardTitle>
+                    <CardDescription>
+                        {[pet.species, pet.gender, ageLabel(pet.birthDate)]
+                            .filter(Boolean)
+                            .join(" · ")}
+                    </CardDescription>
+                </div>
+                {canEdit && !editing && (
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setEditing(true)}
+                    >
+                        <Pencil className="mr-1 h-3.5 w-3.5" />
+                        Edit
+                    </Button>
+                )}
+            </CardHeader>
+            {editing && (
+                <CardContent>
+                    <form onSubmit={onSubmit} className="space-y-3">
+                        <div className="space-y-1">
+                            <Label htmlFor="edit-name">Name</Label>
+                            <Input
+                                id="edit-name"
+                                required
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                            />
+                        </div>
+                        <div className="space-y-1">
+                            <Label htmlFor="edit-species">Species</Label>
+                            <select
+                                id="edit-species"
+                                value={species}
+                                onChange={(e) => setSpecies(e.target.value)}
+                                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                            >
+                                <option value="Cat">Cat</option>
+                                <option value="Dog">Dog</option>
+                                <option value="Other">Other</option>
+                            </select>
+                        </div>
+                        <div className="space-y-1">
+                            <Label htmlFor="edit-gender">Gender</Label>
+                            <select
+                                id="edit-gender"
+                                value={gender}
+                                onChange={(e) => setGender(e.target.value)}
+                                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                            >
+                                <option value="Female">Female</option>
+                                <option value="Male">Male</option>
+                                <option value="Unknown">Unknown</option>
+                            </select>
+                        </div>
+                        <div className="space-y-1">
+                            <Label htmlFor="edit-birth">Birth date</Label>
+                            <Input
+                                id="edit-birth"
+                                type="date"
+                                value={birthDate}
+                                onChange={(e) => setBirthDate(e.target.value)}
+                                max={new Date().toISOString().slice(0, 10)}
+                            />
+                        </div>
+                        {updatePet.error && (
+                            <p className="text-sm text-destructive">
+                                {updatePet.error.message}
+                            </p>
+                        )}
+                        <div className="flex justify-end gap-2 pt-1">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => setEditing(false)}
+                                disabled={updatePet.isPending}
+                            >
+                                Cancel
+                            </Button>
+                            <Button type="submit" disabled={updatePet.isPending}>
+                                {updatePet.isPending ? "Saving…" : "Save"}
+                            </Button>
+                        </div>
+                    </form>
+                </CardContent>
+            )}
+        </Card>
+    );
+}
+
+function ageLabel(birthDate: string | null): string | null {
+    if (!birthDate) return null;
+    const born = new Date(birthDate);
+    const now = new Date();
+    const months =
+        (now.getFullYear() - born.getFullYear()) * 12 +
+        (now.getMonth() - born.getMonth());
+    if (months < 12) return `${months} mo old`;
+    const years = Math.floor(months / 12);
+    return `${years} yr old`;
+}

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -6,6 +6,7 @@ import { TRPCError } from "@trpc/server";
 import { Button } from "~/components/ui/button";
 import { PetEditCard } from "~/app/dashboard/pets/[id]/_components/pet-edit-card";
 import { FeedingHistoryList } from "~/app/dashboard/pets/[id]/_components/feeding-history-list";
+import { DeletePetCard } from "~/app/dashboard/pets/[id]/_components/delete-pet-card";
 import { WeightChart } from "~/app/dashboard/_components/weight-chart";
 import { api } from "~/trpc/server";
 
@@ -39,6 +40,7 @@ export default async function PetDetailPage({
             <PetEditCard pet={pet} />
             <WeightChart petId={pet.id} petName={pet.name} />
             <FeedingHistoryList petId={pet.id} />
+            <DeletePetCard petId={pet.id} petName={pet.name} role={pet.role} />
         </div>
     );
 }

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+import { TRPCError } from "@trpc/server";
+
+import { Button } from "~/components/ui/button";
+import { PetEditCard } from "~/app/dashboard/pets/[id]/_components/pet-edit-card";
+import { FeedingHistoryList } from "~/app/dashboard/pets/[id]/_components/feeding-history-list";
+import { WeightChart } from "~/app/dashboard/_components/weight-chart";
+import { api } from "~/trpc/server";
+
+export default async function PetDetailPage({
+    params,
+}: {
+    params: { id: string };
+}) {
+    const petId = Number(params.id);
+    if (!Number.isFinite(petId) || petId <= 0) notFound();
+
+    let pet;
+    try {
+        pet = await api.pet.getPet({ petId });
+    } catch (err) {
+        if (err instanceof TRPCError && err.code === "FORBIDDEN") notFound();
+        if (err instanceof TRPCError && err.code === "NOT_FOUND") notFound();
+        throw err;
+    }
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <Button asChild variant="ghost" size="sm" className="-ml-2">
+                    <Link href="/dashboard">
+                        <ChevronLeft className="mr-1 h-4 w-4" />
+                        Dashboard
+                    </Link>
+                </Button>
+            </div>
+            <PetEditCard pet={pet} />
+            <WeightChart petId={pet.id} petName={pet.name} />
+            <FeedingHistoryList petId={pet.id} />
+        </div>
+    );
+}

--- a/src/env.js
+++ b/src/env.js
@@ -11,6 +11,7 @@ export const env = createEnv({
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
+    CLERK_WEBHOOK_SECRET: z.string().optional(),
   },
 
   /**
@@ -29,6 +30,7 @@ export const env = createEnv({
   runtimeEnv: {
     POSTGRES_URL: process.env.POSTGRES_URL,
     NODE_ENV: process.env.NODE_ENV,
+    CLERK_WEBHOOK_SECRET: process.env.CLERK_WEBHOOK_SECRET,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
   },
   /**

--- a/src/schema/getPetInput.ts
+++ b/src/schema/getPetInput.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const getPetInput = z.object({
+    petId: z.number().int().positive(),
+});

--- a/src/schema/updatePetInput.ts
+++ b/src/schema/updatePetInput.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const updatePetInput = z.object({
+    petId: z.number().int().positive(),
+    name: z.string().min(1).max(128).optional(),
+    species: z.string().min(1).max(64).optional(),
+    gender: z.string().min(1).max(16).optional(),
+    birthDate: z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/, "Expected YYYY-MM-DD")
+        .nullable()
+        .optional(),
+});
+
+export type UpdatePetInput = z.infer<typeof updatePetInput>;

--- a/src/server/api/petAccess.ts
+++ b/src/server/api/petAccess.ts
@@ -1,11 +1,12 @@
 import { TRPCError } from "@trpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 
 import { type db } from "~/server/db";
-import { petPeople } from "~/server/db/schema";
+import { petPeople, pets } from "~/server/db/schema";
 
 /**
- * Throws FORBIDDEN if the user does not have a row in petPeople for the given pet.
+ * Throws FORBIDDEN if the user does not have a row in petPeople for the given pet,
+ * or NOT_FOUND if the pet is soft-deleted (deletedAt IS NOT NULL).
  * Returns the user's role on success in case callers want to gate writes on it.
  */
 export async function assertPetAccess(
@@ -16,6 +17,10 @@ export async function assertPetAccess(
     const rows = await database
         .select({ role: petPeople.role })
         .from(petPeople)
+        .innerJoin(
+            pets,
+            and(eq(pets.id, petPeople.petId), isNull(pets.deletedAt)),
+        )
         .where(and(eq(petPeople.petId, petId), eq(petPeople.userId, userId)))
         .limit(1);
 

--- a/src/server/api/routers/feeding.ts
+++ b/src/server/api/routers/feeding.ts
@@ -1,7 +1,7 @@
-import { asc, eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
-import { eatingHistory } from "~/server/db/schema";
+import { eatingHistory, petFood } from "~/server/db/schema";
 import { getFeedingHistoryInput } from "~/schema/getFeedingHistoryInput";
 import { recordFeedingInput } from "~/schema/recordFeedingInput";
 import { assertPetAccess } from "~/server/api/petAccess";
@@ -35,9 +35,16 @@ export const feedingRouter = createTRPCRouter({
             await assertPetAccess(ctx.db, ctx.userId, input.petId);
 
             return ctx.db
-                .select()
+                .select({
+                    id: eatingHistory.id,
+                    petId: eatingHistory.petId,
+                    fedAt: eatingHistory.fedAt,
+                    quantityGrams: eatingHistory.quantityGrams,
+                    food: petFood,
+                })
                 .from(eatingHistory)
+                .innerJoin(petFood, eq(eatingHistory.foodId, petFood.id))
                 .where(eq(eatingHistory.petId, input.petId))
-                .orderBy(asc(eatingHistory.fedAt));
+                .orderBy(desc(eatingHistory.fedAt));
         }),
 });

--- a/src/server/api/routers/pet.ts
+++ b/src/server/api/routers/pet.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
@@ -54,7 +54,9 @@ export const petRouter = createTRPCRouter({
             })
             .from(pets)
             .innerJoin(petPeople, eq(pets.id, petPeople.petId))
-            .where(eq(petPeople.userId, ctx.userId));
+            .where(
+                and(eq(petPeople.userId, ctx.userId), isNull(pets.deletedAt)),
+            );
     }),
 
     getPet: protectedProcedure
@@ -64,7 +66,7 @@ export const petRouter = createTRPCRouter({
             const [row] = await ctx.db
                 .select()
                 .from(pets)
-                .where(eq(pets.id, input.petId))
+                .where(and(eq(pets.id, input.petId), isNull(pets.deletedAt)))
                 .limit(1);
             if (!row) {
                 throw new TRPCError({ code: "NOT_FOUND" });
@@ -102,5 +104,23 @@ export const petRouter = createTRPCRouter({
                 });
             }
             return row;
+        }),
+
+    deletePet: protectedProcedure
+        .input(getPetInput)
+        .mutation(async ({ ctx, input }) => {
+            const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            if (role !== "Owner") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Only the Owner can delete a pet.",
+                });
+            }
+            const now = new Date();
+            await ctx.db
+                .update(pets)
+                .set({ deletedAt: now, updatedAt: now })
+                .where(eq(pets.id, input.petId));
+            return { ok: true as const };
         }),
 });

--- a/src/server/api/routers/pet.ts
+++ b/src/server/api/routers/pet.ts
@@ -3,7 +3,10 @@ import { TRPCError } from "@trpc/server";
 
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { createPetRequestInput } from "~/schema/createPetRequestInput";
+import { getPetInput } from "~/schema/getPetInput";
+import { updatePetInput } from "~/schema/updatePetInput";
 import { petPeople, pets } from "~/server/db/schema";
+import { assertPetAccess } from "~/server/api/petAccess";
 
 export const petRouter = createTRPCRouter({
     insertPet: protectedProcedure
@@ -53,4 +56,51 @@ export const petRouter = createTRPCRouter({
             .innerJoin(petPeople, eq(pets.id, petPeople.petId))
             .where(eq(petPeople.userId, ctx.userId));
     }),
+
+    getPet: protectedProcedure
+        .input(getPetInput)
+        .query(async ({ ctx, input }) => {
+            const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            const [row] = await ctx.db
+                .select()
+                .from(pets)
+                .where(eq(pets.id, input.petId))
+                .limit(1);
+            if (!row) {
+                throw new TRPCError({ code: "NOT_FOUND" });
+            }
+            return { ...row, role };
+        }),
+
+    updatePet: protectedProcedure
+        .input(updatePetInput)
+        .mutation(async ({ ctx, input }) => {
+            const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot edit this pet.",
+                });
+            }
+
+            const patch: Record<string, unknown> = { updatedAt: new Date() };
+            if (input.name !== undefined) patch.name = input.name;
+            if (input.species !== undefined) patch.species = input.species;
+            if (input.gender !== undefined) patch.gender = input.gender;
+            if (input.birthDate !== undefined) patch.birthDate = input.birthDate;
+
+            const [row] = await ctx.db
+                .update(pets)
+                .set(patch)
+                .where(eq(pets.id, input.petId))
+                .returning();
+
+            if (!row) {
+                throw new TRPCError({
+                    code: "INTERNAL_SERVER_ERROR",
+                    message: "Failed to update pet.",
+                });
+            }
+            return row;
+        }),
 });

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -12,7 +12,6 @@ import superjson from "superjson";
 import { ZodError } from "zod";
 
 import { db } from "~/server/db";
-import { users } from "~/server/db/schema";
 
 /**
  * 1. CONTEXT
@@ -70,39 +69,21 @@ export const createCallerFactory = t.createCallerFactory;
  * "/src/server/api/routers" directory.
  */
 
-/**
- * This is how you create new routers and sub-routers in your tRPC API.
- *
- * @see https://trpc.io/docs/router
- */
 export const createTRPCRouter = t.router;
 
-/**
- * Public (unauthenticated) procedure
- *
- * This is the base piece you use to build new queries and mutations on your tRPC API. It does not
- * guarantee that a user querying is authorized, but you can still access user session data if they
- * are logged in.
- */
 export const publicProcedure = t.procedure;
 
 /**
  * Protected (authenticated) procedure.
  *
- * Requires a signed-in Clerk user. Lazily upserts the user into our `users` table on first call so
- * downstream foreign keys (e.g. `petPeople.userId`) are always valid without needing a separate
- * Clerk webhook.
+ * Requires a signed-in Clerk user. The `users` row is populated by the Clerk
+ * webhook at /api/clerk/webhook on user.created — there is no lazy upsert
+ * here anymore.
  */
 const enforceUserIsAuthed = t.middleware(async ({ ctx, next }) => {
   if (!ctx.userId) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
-
-  await ctx.db
-    .insert(users)
-    .values({ id: ctx.userId })
-    .onConflictDoNothing();
-
   return next({ ctx: { ...ctx, userId: ctx.userId } });
 });
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -36,6 +36,7 @@ export const pets = createTable("pets", {
     gender: varchar("gender", { length: 16 }).notNull(),
     name: varchar("name", { length: 128 }).notNull(),
     birthDate: date("birth_date"),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
     ...timestamps,
 });
 


### PR DESCRIPTION
## Summary
Stack 8. Adds the "what did this cat eat today" card to the dashboard.

### Changes
- `feeding.getFeedingHistory` now inner-joins `petFood` and returns the food row embedded as `.food`. Ordering switched to descending `fedAt`. No other call sites consume this query yet, so the shape change is safe.
- `TodayFeedings` dashboard card:
  - Filters joined feedings to the local-day window
  - Renders per-feeding: food name (with brand prefix), time, grams, computed kcal
  - Sums and displays today's total kcal in the header
  - Loading + empty states

### Test plan
- [x] `pnpm typecheck` / `pnpm lint` clean
- [ ] With no feedings today, card shows empty state and `0 kcal today`
- [ ] Log a feeding → it appears, kcal sum updates
- [ ] Log multiple feedings for the same pet → list ordered most-recent first, total reflects sum
- [ ] Switch pets → card re-queries and shows that pet's day

### Out of scope
- Daily kcal *target* (no column on `pets` yet — add later with goals)
- Yesterday / weekly views
- Edit / delete individual feedings (likely lands with S9 or its own stack)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_