### PR TITLE
S17: per-pet CSV export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Lint
         run: pnpm lint
+
+      - name: Test
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    env:
+      SKIP_ENV_VALIDATION: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint

--- a/drizzle/0003_kind_prodigy.sql
+++ b/drizzle/0003_kind_prodigy.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "meow-weight-tracker_activity_history" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"pet_id" integer NOT NULL,
+	"activity_type" varchar(64) NOT NULL,
+	"duration_minutes" integer NOT NULL,
+	"performed_at" timestamp with time zone NOT NULL,
+	"notes" varchar(1024),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "meow-weight-tracker_activity_history" ADD CONSTRAINT "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk" FOREIGN KEY ("pet_id") REFERENCES "public"."meow-weight-tracker_pets"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "activity_history_pet_id_idx" ON "meow-weight-tracker_activity_history" ("pet_id");

--- a/drizzle/0004_fat_overlord.sql
+++ b/drizzle/0004_fat_overlord.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "meow-weight-tracker_health_events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"pet_id" integer NOT NULL,
+	"event_type" varchar(64) NOT NULL,
+	"title" varchar(256) NOT NULL,
+	"occurred_at" timestamp with time zone NOT NULL,
+	"notes" varchar(2048),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "meow-weight-tracker_health_events" ADD CONSTRAINT "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk" FOREIGN KEY ("pet_id") REFERENCES "public"."meow-weight-tracker_pets"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "health_events_pet_id_idx" ON "meow-weight-tracker_health_events" ("pet_id");

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,541 @@
+{
+  "id": "21ed2245-6880-48c8-89a5-6173cae9d3ff",
+  "prevId": "2f51bd95-385c-45b2-868a-bfedefff1d8f",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.meow-weight-tracker_activity_history": {
+      "name": "meow-weight-tracker_activity_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_history_pet_id_idx": {
+          "name": "activity_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_activity_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_eating_history": {
+      "name": "meow-weight-tracker_eating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fed_at": {
+          "name": "fed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_grams": {
+          "name": "quantity_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eating_history_pet_id_idx": {
+          "name": "eating_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk": {
+          "name": "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pet_food",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_food": {
+      "name": "meow-weight-tracker_pet_food",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories_per_gram": {
+          "name": "calories_per_gram",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_percent": {
+          "name": "protein_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat_percent": {
+          "name": "fat_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs_percent": {
+          "name": "carbs_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_food_name_idx": {
+          "name": "pet_food_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_people": {
+      "name": "meow-weight-tracker_pet_people",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_people_user_id_idx": {
+          "name": "pet_people_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "pet_people_pet_id_idx": {
+          "name": "pet_people_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meow-weight-tracker_pet_people_user_id_pet_id_pk": {
+          "name": "meow-weight-tracker_pet_people_user_id_pet_id_pk",
+          "columns": [
+            "user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pets": {
+      "name": "meow-weight-tracker_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_weight": {
+          "name": "goal_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_kcal_target": {
+          "name": "daily_kcal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_users": {
+      "name": "meow-weight-tracker_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_weight_history": {
+      "name": "meow-weight-tracker_weight_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weighed_at": {
+          "name": "weighed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weight_history_pet_id_idx": {
+          "name": "weight_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_weight_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.pet_role": {
+      "name": "pet_role",
+      "schema": "public",
+      "values": [
+        "Owner",
+        "Editor",
+        "Viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,623 @@
+{
+  "id": "c39b63ea-dac6-4a1d-8aa4-08014058a27d",
+  "prevId": "21ed2245-6880-48c8-89a5-6173cae9d3ff",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.meow-weight-tracker_activity_history": {
+      "name": "meow-weight-tracker_activity_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_history_pet_id_idx": {
+          "name": "activity_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_activity_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_eating_history": {
+      "name": "meow-weight-tracker_eating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fed_at": {
+          "name": "fed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_grams": {
+          "name": "quantity_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eating_history_pet_id_idx": {
+          "name": "eating_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk": {
+          "name": "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pet_food",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_health_events": {
+      "name": "meow-weight-tracker_health_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_events_pet_id_idx": {
+          "name": "health_events_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_health_events",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_food": {
+      "name": "meow-weight-tracker_pet_food",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories_per_gram": {
+          "name": "calories_per_gram",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_percent": {
+          "name": "protein_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat_percent": {
+          "name": "fat_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs_percent": {
+          "name": "carbs_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_food_name_idx": {
+          "name": "pet_food_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_people": {
+      "name": "meow-weight-tracker_pet_people",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_people_user_id_idx": {
+          "name": "pet_people_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "pet_people_pet_id_idx": {
+          "name": "pet_people_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meow-weight-tracker_pet_people_user_id_pet_id_pk": {
+          "name": "meow-weight-tracker_pet_people_user_id_pet_id_pk",
+          "columns": [
+            "user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pets": {
+      "name": "meow-weight-tracker_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_weight": {
+          "name": "goal_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_kcal_target": {
+          "name": "daily_kcal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_users": {
+      "name": "meow-weight-tracker_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_weight_history": {
+      "name": "meow-weight-tracker_weight_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weighed_at": {
+          "name": "weighed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weight_history_pet_id_idx": {
+          "name": "weight_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_weight_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.pet_role": {
+      "name": "pet_role",
+      "schema": "public",
+      "values": [
+        "Owner",
+        "Editor",
+        "Viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1778704525348,
       "tag": "0002_fearless_steel_serpent",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1778705076049,
+      "tag": "0003_kind_prodigy",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1778705076049,
       "tag": "0003_kind_prodigy",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1778705180664,
+      "tag": "0004_fat_overlord",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -51,15 +52,18 @@
     "@types/react-dom": "^18.2.19",
     "@typescript-eslint/eslint-plugin": "^7.1.1",
     "@typescript-eslint/parser": "^7.1.1",
+    "@vitejs/plugin-react": "^6.0.1",
     "drizzle-kit": "^0.21.4",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.1.3",
     "eslint-plugin-drizzle": "^0.2.3",
+    "jsdom": "^29.1.1",
     "postcss": "^8.4.34",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.14",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.2",
+    "vitest": "^4.1.6"
   },
   "ct3aMetadata": {
     "initVersion": "7.34.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^7.1.1
         version: 7.13.0(eslint@8.57.0)(typescript@5.4.5)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.12(@types/node@20.14.2)(esbuild@0.19.12)(jiti@1.21.6)(yaml@2.4.5))
       drizzle-kit:
         specifier: ^0.21.4
         version: 0.21.4
@@ -123,6 +126,9 @@ importers:
       eslint-plugin-drizzle:
         specifier: ^0.2.3
         version: 0.2.3(eslint@8.57.0)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       postcss:
         specifier: ^8.4.34
         version: 8.4.38
@@ -138,6 +144,9 @@ importers:
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@20.14.2)(jsdom@29.1.1)(vite@8.0.12(@types/node@20.14.2)(esbuild@0.19.12)(jiti@1.21.6)(yaml@2.4.5))
 
 packages:
 
@@ -145,9 +154,28 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
   '@babel/runtime@7.24.7':
     resolution: {integrity: sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==}
     engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
 
   '@clerk/backend@1.2.3':
     resolution: {integrity: sha512-tj812eTTn2ewXMgr4jwFjpqoXZRF2LMw9UBT+Nat0lmXw55sDA5ou2McLZ67e62WNZwbrCUa51MGKSBhrWnZcA==}
@@ -183,6 +211,51 @@ packages:
   '@clerk/types@4.6.0':
     resolution: {integrity: sha512-kowqVGqLfu0Zl2Pteum70MfkGHqBUoHHeR+u2+yWVl1lKHLCiyY1u8ntYBEIolAylBaQNDuRzxyMIDPSxjPE8g==}
     engines: {node: '>=18.17.0'}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.1':
+    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4':
+    resolution: {integrity: sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -478,6 +551,15 @@ packages:
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -525,8 +607,17 @@ packages:
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@neondatabase/serverless@0.7.2':
     resolution: {integrity: sha512-wU3WA2uTyNO7wjPs3Mg0G01jztAxUxzd9/mskMmtPwPTjf7JKWi9AW5/puOGXLxmZ9PVgRFeBVRVYq5nBPhsCg==}
@@ -602,6 +693,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxc-project/types@0.129.0':
+    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -931,6 +1025,101 @@ packages:
       react-redux:
         optional: true
 
+  '@rolldown/binding-android-arm64@1.0.0':
+    resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0':
+    resolution: {integrity: sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0':
+    resolution: {integrity: sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+    resolution: {integrity: sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0':
+    resolution: {integrity: sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0':
+    resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
+    resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+    resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0':
+    resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0':
+    resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0':
+    resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0':
+    resolution: {integrity: sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+    resolution: {integrity: sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0':
+    resolution: {integrity: sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0':
+    resolution: {integrity: sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==}
+
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
   '@rushstack/eslint-patch@1.10.3':
     resolution: {integrity: sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==}
 
@@ -992,6 +1181,12 @@ packages:
   '@trpc/server@11.0.0-rc.403':
     resolution: {integrity: sha512-DIt0GijW3nzq3zk9rFw1Ly/b6E9eTcsKV+caOMSeJl6A7Pby8QpdKaN8yJZDHhEojULeIVFNE4Izals5T0fQgg==}
 
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -1018,6 +1213,9 @@ packages:
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/eslint@8.56.10':
     resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
@@ -1168,6 +1366,48 @@ packages:
       vue-router:
         optional: true
 
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1256,6 +1496,10 @@ packages:
     resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -1272,6 +1516,9 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1313,6 +1560,10 @@ packages:
   caniuse-lite@1.0.30001634:
     resolution: {integrity: sha512-fbBYXQ9q3+yp1q1gBk86tOFs4pyn/yxFm5ZNP18OXJDfA3txImOY9PhfxVggZ4vRHDqoU8NrKU81eN0OtzOgRA==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1353,6 +1604,9 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
@@ -1367,6 +1621,10 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1430,6 +1688,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   data-view-buffer@1.0.1:
     resolution: {integrity: sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==}
     engines: {node: '>= 0.4'}
@@ -1462,6 +1724,9 @@ packages:
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1476,6 +1741,10 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
@@ -1605,6 +1874,10 @@ packages:
     resolution: {integrity: sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==}
     engines: {node: '>=10.13.0'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1624,6 +1897,9 @@ packages:
   es-iterator-helpers@1.0.19:
     resolution: {integrity: sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.0.0:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
@@ -1782,6 +2058,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1791,6 +2070,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
@@ -1813,6 +2096,15 @@ packages:
 
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -1961,6 +2253,10 @@ packages:
   heap@0.2.7:
     resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
@@ -2067,6 +2363,9 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
 
@@ -2141,6 +2440,15 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -2176,6 +2484,76 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
@@ -2208,6 +2586,10 @@ packages:
     resolution: {integrity: sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
+
   lru-queue@0.1.0:
     resolution: {integrity: sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==}
 
@@ -2216,9 +2598,15 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   map-obj@4.3.0:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   memoizee@0.4.17:
     resolution: {integrity: sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==}
@@ -2262,6 +2650,11 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
@@ -2342,6 +2735,9 @@ packages:
     resolution: {integrity: sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2360,6 +2756,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2387,6 +2786,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
@@ -2401,9 +2803,16 @@ packages:
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -2460,6 +2869,10 @@ packages:
 
   postcss@8.4.38:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -2641,6 +3054,10 @@ packages:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
@@ -2668,6 +3085,11 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rolldown@1.0.0:
+    resolution: {integrity: sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2678,6 +3100,10 @@ packages:
   safe-regex-test@1.0.3:
     resolution: {integrity: sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==}
     engines: {node: '>= 0.4'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -2714,6 +3140,9 @@ packages:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2736,6 +3165,10 @@ packages:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
@@ -2743,11 +3176,17 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -2830,6 +3269,9 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
@@ -2864,9 +3306,39 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@1.3.0:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
@@ -2928,6 +3400,10 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -2971,6 +3447,106 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
+  vite@8.0.12:
+    resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
 
@@ -2989,6 +3565,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3021,6 +3602,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -3041,9 +3629,33 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
   '@babel/runtime@7.24.7':
     dependencies:
       regenerator-runtime: 0.14.1
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@clerk/backend@1.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -3091,6 +3703,46 @@ snapshots:
   '@clerk/types@4.6.0':
     dependencies:
       csstype: 3.1.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.6.3
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.6.3
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.6.3
+    optional: true
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
@@ -3260,6 +3912,8 @@ snapshots:
 
   '@eslint/js@8.57.0': {}
 
+  '@exodus/bytes@1.15.0': {}
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -3310,10 +3964,19 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
 
   '@neondatabase/serverless@0.7.2':
     dependencies:
@@ -3363,6 +4026,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@oxc-project/types@0.129.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -3654,6 +4319,59 @@ snapshots:
       react: 18.3.1
       react-redux: 9.2.0(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1)
 
+  '@rolldown/binding-android-arm64@1.0.0':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
+
   '@rushstack/eslint-patch@1.10.3': {}
 
   '@stablelib/base64@1.0.1': {}
@@ -3703,6 +4421,16 @@ snapshots:
 
   '@trpc/server@11.0.0-rc.403': {}
 
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.6.3
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -3726,6 +4454,8 @@ snapshots:
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/eslint@8.56.10':
     dependencies:
@@ -3896,6 +4626,52 @@ snapshots:
       next: 14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
+  '@vitejs/plugin-react@6.0.1(vite@8.0.12(@types/node@20.14.2)(esbuild@0.19.12)(jiti@1.21.6)(yaml@2.4.5))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      vite: 8.0.12(@types/node@20.14.2)(esbuild@0.19.12)(jiti@1.21.6)(yaml@2.4.5)
+
+  '@vitest/expect@4.1.6':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.6(vite@8.0.12(@types/node@20.14.2)(esbuild@0.19.12)(jiti@1.21.6)(yaml@2.4.5))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.12(@types/node@20.14.2)(esbuild@0.19.12)(jiti@1.21.6)(yaml@2.4.5)
+
+  '@vitest/pretty-format@4.1.6':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.6':
+    dependencies:
+      '@vitest/utils': 4.1.6
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.6': {}
+
+  '@vitest/utils@4.1.6':
+    dependencies:
+      '@vitest/pretty-format': 4.1.6
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.12.0):
     dependencies:
       acorn: 8.12.0
@@ -4012,6 +4788,8 @@ snapshots:
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.3
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   available-typed-arrays@1.0.7:
@@ -4025,6 +4803,10 @@ snapshots:
       dequal: 2.0.3
 
   balanced-match@1.0.2: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   binary-extensions@2.3.0: {}
 
@@ -4064,6 +4846,8 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001634: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4110,6 +4894,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie@0.5.0: {}
 
   copy-anything@3.0.5:
@@ -4123,6 +4909,11 @@ snapshots:
       which: 2.0.2
 
   crypto-js@4.2.0: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
 
   cssesc@3.0.0: {}
 
@@ -4175,6 +4966,13 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   data-view-buffer@1.0.1:
     dependencies:
       call-bind: 1.0.7
@@ -4203,6 +5001,8 @@ snapshots:
 
   decimal.js-light@2.5.1: {}
 
+  decimal.js@10.6.0: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -4218,6 +5018,8 @@ snapshots:
       object-keys: 1.1.1
 
   dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
@@ -4283,6 +5085,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+
+  entities@8.0.0: {}
 
   env-paths@3.0.0: {}
 
@@ -4357,6 +5161,8 @@ snapshots:
       internal-slot: 1.0.7
       iterator.prototype: 1.1.2
       safe-array-concat: 1.1.2
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.0.0:
     dependencies:
@@ -4679,6 +5485,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.5
+
   esutils@2.0.3: {}
 
   event-emitter@0.3.5:
@@ -4687,6 +5497,8 @@ snapshots:
       es5-ext: 0.10.64
 
   eventemitter3@5.0.4: {}
+
+  expect-type@1.3.0: {}
 
   ext@1.7.0:
     dependencies:
@@ -4711,6 +5523,10 @@ snapshots:
   fastq@1.17.1:
     dependencies:
       reusify: 1.0.4
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -4878,6 +5694,12 @@ snapshots:
 
   heap@0.2.7: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   ignore@5.3.1: {}
 
   immer@10.2.0: {}
@@ -4970,6 +5792,8 @@ snapshots:
 
   is-path-inside@3.0.3: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@2.2.2: {}
 
   is-regex@1.1.4:
@@ -5042,6 +5866,32 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.6
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   json-buffer@3.0.1: {}
 
   json-diff@0.9.0:
@@ -5080,6 +5930,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lilconfig@2.1.0: {}
 
   lilconfig@3.1.2: {}
@@ -5104,6 +6003,8 @@ snapshots:
 
   lru-cache@10.2.2: {}
 
+  lru-cache@11.3.6: {}
+
   lru-queue@0.1.0:
     dependencies:
       es5-ext: 0.10.64
@@ -5112,7 +6013,13 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   map-obj@4.3.0: {}
+
+  mdn-data@2.27.1: {}
 
   memoizee@0.4.17:
     dependencies:
@@ -5161,6 +6068,8 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+
+  nanoid@3.3.12: {}
 
   nanoid@3.3.7: {}
 
@@ -5248,6 +6157,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
 
+  obug@2.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -5273,6 +6184,10 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -5290,6 +6205,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   pg-int8@1.0.1: {}
 
   pg-protocol@1.6.1: {}
@@ -5304,7 +6221,11 @@ snapshots:
 
   picocolors@1.0.1: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
+
+  picomatch@4.0.4: {}
 
   pify@2.3.0: {}
 
@@ -5354,6 +6275,12 @@ snapshots:
       nanoid: 3.3.7
       picocolors: 1.0.1
       source-map-js: 1.2.0
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postgres-array@2.0.0: {}
 
@@ -5486,6 +6413,8 @@ snapshots:
       es-errors: 1.3.0
       set-function-name: 2.0.2
 
+  require-from-string@2.0.2: {}
+
   reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
@@ -5510,6 +6439,27 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  rolldown@1.0.0:
+    dependencies:
+      '@oxc-project/types': 0.129.0
+      '@rolldown/pluginutils': 1.0.0
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0
+      '@rolldown/binding-darwin-arm64': 1.0.0
+      '@rolldown/binding-darwin-x64': 1.0.0
+      '@rolldown/binding-freebsd-x64': 1.0.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0
+      '@rolldown/binding-linux-arm64-musl': 1.0.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0
+      '@rolldown/binding-linux-x64-gnu': 1.0.0
+      '@rolldown/binding-linux-x64-musl': 1.0.0
+      '@rolldown/binding-openharmony-arm64': 1.0.0
+      '@rolldown/binding-wasm32-wasi': 1.0.0
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0
+      '@rolldown/binding-win32-x64-msvc': 1.0.0
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -5526,6 +6476,10 @@ snapshots:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-regex: 1.1.4
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -5566,6 +6520,8 @@ snapshots:
       get-intrinsic: 1.2.4
       object-inspect: 1.13.1
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
@@ -5585,6 +6541,8 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
+  source-map-js@1.2.1: {}
+
   source-map-support@0.5.21:
     dependencies:
       buffer-from: 1.1.2
@@ -5592,12 +6550,16 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  stackback@0.0.2: {}
+
   standardwebhooks@1.0.0:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
 
   std-env@3.7.0: {}
+
+  std-env@4.1.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -5694,6 +6656,8 @@ snapshots:
       react: 18.3.1
       use-sync-external-store: 1.2.2(react@18.3.1)
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.6.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.4):
@@ -5746,9 +6710,34 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.0.30: {}
+
+  tldts@7.0.30:
+    dependencies:
+      tldts-core: 7.0.30
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.30
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@1.3.0(typescript@5.4.5):
     dependencies:
@@ -5820,6 +6809,8 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  undici@7.25.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -5870,6 +6861,64 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite@8.0.12(@types/node@20.14.2)(esbuild@0.19.12)(jiti@1.21.6)(yaml@2.4.5):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.14.2
+      esbuild: 0.19.12
+      fsevents: 2.3.3
+      jiti: 1.21.6
+      yaml: 2.4.5
+
+  vitest@4.1.6(@types/node@20.14.2)(jsdom@29.1.1)(vite@8.0.12(@types/node@20.14.2)(esbuild@0.19.12)(jiti@1.21.6)(yaml@2.4.5)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@20.14.2)(esbuild@0.19.12)(jiti@1.21.6)(yaml@2.4.5))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.12(@types/node@20.14.2)(esbuild@0.19.12)(jiti@1.21.6)(yaml@2.4.5)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.14.2
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   which-boxed-primitive@1.0.2:
     dependencies:
       is-bigint: 1.0.4
@@ -5912,6 +6961,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   wordwrap@1.0.0: {}
@@ -5934,6 +6988,10 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 6.0.3
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 

--- a/src/app/api/pets/[id]/export/route.ts
+++ b/src/app/api/pets/[id]/export/route.ts
@@ -1,0 +1,115 @@
+import { auth } from "@clerk/nextjs/server";
+import { asc, eq } from "drizzle-orm";
+
+import { db } from "~/server/db";
+import { eatingHistory, petFood, weightHistory } from "~/server/db/schema";
+import { assertPetAccess } from "~/server/api/petAccess";
+
+function csvEscape(value: unknown): string {
+    if (value === null || value === undefined) return "";
+    const s = String(value);
+    if (s.includes(",") || s.includes('"') || s.includes("\n")) {
+        return `"${s.replace(/"/g, '""')}"`;
+    }
+    return s;
+}
+
+function toCsv(rows: ReadonlyArray<ReadonlyArray<unknown>>): string {
+    return rows.map((r) => r.map(csvEscape).join(",")).join("\n") + "\n";
+}
+
+export async function GET(
+    req: Request,
+    { params }: { params: { id: string } },
+) {
+    const { userId } = auth();
+    if (!userId) {
+        return new Response("Unauthorized", { status: 401 });
+    }
+    const petId = Number(params.id);
+    if (!Number.isFinite(petId) || petId <= 0) {
+        return new Response("Bad petId", { status: 400 });
+    }
+    try {
+        await assertPetAccess(db, userId, petId);
+    } catch {
+        return new Response("Forbidden", { status: 403 });
+    }
+
+    const url = new URL(req.url);
+    const kind = url.searchParams.get("kind") ?? "weight";
+
+    if (kind === "weight") {
+        const rows = await db
+            .select()
+            .from(weightHistory)
+            .where(eq(weightHistory.petId, petId))
+            .orderBy(asc(weightHistory.weighedAt));
+        const csv = toCsv([
+            ["entry_id", "weighed_at_iso", "weight", "created_at_iso"],
+            ...rows.map((r) => [
+                r.id,
+                r.weighedAt.toISOString(),
+                r.weight,
+                r.createdAt.toISOString(),
+            ]),
+        ]);
+        return new Response(csv, {
+            status: 200,
+            headers: {
+                "Content-Type": "text/csv; charset=utf-8",
+                "Content-Disposition": `attachment; filename="pet-${petId}-weight.csv"`,
+            },
+        });
+    }
+
+    if (kind === "feeding") {
+        const rows = await db
+            .select({
+                id: eatingHistory.id,
+                fedAt: eatingHistory.fedAt,
+                quantityGrams: eatingHistory.quantityGrams,
+                createdAt: eatingHistory.createdAt,
+                foodName: petFood.name,
+                foodBrand: petFood.brand,
+                caloriesPerGram: petFood.caloriesPerGram,
+            })
+            .from(eatingHistory)
+            .innerJoin(petFood, eq(eatingHistory.foodId, petFood.id))
+            .where(eq(eatingHistory.petId, petId))
+            .orderBy(asc(eatingHistory.fedAt));
+        const csv = toCsv([
+            [
+                "entry_id",
+                "fed_at_iso",
+                "food_name",
+                "food_brand",
+                "quantity_grams",
+                "calories_per_gram",
+                "computed_kcal",
+                "created_at_iso",
+            ],
+            ...rows.map((r) => [
+                r.id,
+                r.fedAt.toISOString(),
+                r.foodName,
+                r.foodBrand ?? "",
+                r.quantityGrams,
+                r.caloriesPerGram,
+                (r.quantityGrams * r.caloriesPerGram).toFixed(2),
+                r.createdAt.toISOString(),
+            ]),
+        ]);
+        return new Response(csv, {
+            status: 200,
+            headers: {
+                "Content-Type": "text/csv; charset=utf-8",
+                "Content-Disposition": `attachment; filename="pet-${petId}-feeding.csv"`,
+            },
+        });
+    }
+
+    return new Response("Unknown kind. Use ?kind=weight or ?kind=feeding", {
+        status: 400,
+    });
+}

--- a/src/app/api/pets/[id]/export/route.ts
+++ b/src/app/api/pets/[id]/export/route.ts
@@ -1,22 +1,10 @@
 import { auth } from "@clerk/nextjs/server";
 import { asc, eq } from "drizzle-orm";
 
+import { toCsv } from "~/lib/csv";
 import { db } from "~/server/db";
 import { eatingHistory, petFood, weightHistory } from "~/server/db/schema";
 import { assertPetAccess } from "~/server/api/petAccess";
-
-function csvEscape(value: unknown): string {
-    if (value === null || value === undefined) return "";
-    const s = String(value);
-    if (s.includes(",") || s.includes('"') || s.includes("\n")) {
-        return `"${s.replace(/"/g, '""')}"`;
-    }
-    return s;
-}
-
-function toCsv(rows: ReadonlyArray<ReadonlyArray<unknown>>): string {
-    return rows.map((r) => r.map(csvEscape).join(",")).join("\n") + "\n";
-}
 
 export async function GET(
     req: Request,

--- a/src/app/dashboard/_components/dashboard-content.tsx
+++ b/src/app/dashboard/_components/dashboard-content.tsx
@@ -7,8 +7,10 @@ import { ChevronRight } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import { PetAlerts } from "~/app/dashboard/_components/pet-alerts";
 import { PetPicker } from "~/app/dashboard/_components/pet-picker";
+import { RecordActivityDialog } from "~/app/dashboard/_components/record-activity-dialog";
 import { RecordFeedingDialog } from "~/app/dashboard/_components/record-feeding-dialog";
 import { RecordWeightDialog } from "~/app/dashboard/_components/record-weight-dialog";
+import { TodayActivity } from "~/app/dashboard/_components/today-activity";
 import { TodayFeedings } from "~/app/dashboard/_components/today-feedings";
 import { WeightChart } from "~/app/dashboard/_components/weight-chart";
 import { WeightStatsCard } from "~/app/dashboard/_components/weight-stats-card";
@@ -36,14 +38,20 @@ export function DashboardContent({ pets }: { pets: Pet[] }) {
                     </Link>
                 </Button>
             </div>
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-4 sm:grid-cols-3">
                 <RecordWeightDialog pet={selectedPet} />
                 <RecordFeedingDialog pet={selectedPet} />
+                <RecordActivityDialog pet={selectedPet} />
             </div>
             <TodayFeedings
                 petId={selectedPet.id}
                 petName={selectedPet.name}
                 dailyKcalTarget={selectedPet.dailyKcalTarget}
+                canEdit={selectedPet.role !== "Viewer"}
+            />
+            <TodayActivity
+                petId={selectedPet.id}
+                petName={selectedPet.name}
                 canEdit={selectedPet.role !== "Viewer"}
             />
             <WeightStatsCard

--- a/src/app/dashboard/_components/record-activity-dialog.tsx
+++ b/src/app/dashboard/_components/record-activity-dialog.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { PlayCircle } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "~/components/ui/dialog";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { api } from "~/trpc/react";
+import { type RouterOutputs } from "~/trpc/react";
+
+type Pet = RouterOutputs["pet"]["getPets"][number];
+
+const ACTIVITY_TYPES = [
+    "Play",
+    "Walk",
+    "Exercise",
+    "Training",
+    "Grooming",
+    "Other",
+];
+
+export function RecordActivityDialog({ pet }: { pet: Pet }) {
+    const [open, setOpen] = useState(false);
+    const [activityType, setActivityType] = useState("Play");
+    const [duration, setDuration] = useState("");
+    const [performedAt, setPerformedAt] = useState("");
+    const [notes, setNotes] = useState("");
+
+    const utils = api.useUtils();
+    const recordActivity = api.activity.record.useMutation({
+        onSuccess: async () => {
+            await utils.activity.getHistory.invalidate({ petId: pet.id });
+            setOpen(false);
+            setDuration("");
+            setPerformedAt("");
+            setNotes("");
+        },
+    });
+
+    function onSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        const mins = Number(duration);
+        if (!Number.isFinite(mins) || mins <= 0) return;
+        recordActivity.mutate({
+            petId: pet.id,
+            activityType,
+            durationMinutes: Math.round(mins),
+            ...(performedAt ? { performedAt: new Date(performedAt) } : {}),
+            ...(notes.trim() ? { notes: notes.trim() } : {}),
+        });
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+                <Card className="cursor-pointer transition-colors hover:bg-accent">
+                    <CardHeader>
+                        <CardTitle className="flex items-center gap-2">
+                            <PlayCircle className="h-4 w-4" />
+                            Log activity
+                        </CardTitle>
+                        <CardDescription>
+                            Track playtime, walks, training.
+                        </CardDescription>
+                    </CardHeader>
+                </Card>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Log activity for {pet.name}</DialogTitle>
+                    <DialogDescription>
+                        Pick a type, enter minutes, save.
+                    </DialogDescription>
+                </DialogHeader>
+                <form onSubmit={onSubmit} className="space-y-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="act-type">Type</Label>
+                        <select
+                            id="act-type"
+                            value={activityType}
+                            onChange={(e) => setActivityType(e.target.value)}
+                            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        >
+                            {ACTIVITY_TYPES.map((t) => (
+                                <option key={t} value={t}>
+                                    {t}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="act-duration">Duration (minutes)</Label>
+                        <Input
+                            id="act-duration"
+                            type="number"
+                            inputMode="numeric"
+                            step="1"
+                            min="1"
+                            required
+                            autoFocus
+                            value={duration}
+                            onChange={(e) => setDuration(e.target.value)}
+                            placeholder="15"
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="act-when">When (optional)</Label>
+                        <Input
+                            id="act-when"
+                            type="datetime-local"
+                            value={performedAt}
+                            onChange={(e) => setPerformedAt(e.target.value)}
+                            max={new Date().toISOString().slice(0, 16)}
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="act-notes">Notes (optional)</Label>
+                        <Input
+                            id="act-notes"
+                            value={notes}
+                            onChange={(e) => setNotes(e.target.value)}
+                            placeholder="Laser pointer, jumping around"
+                        />
+                    </div>
+                    {recordActivity.error && (
+                        <p className="text-sm text-destructive">
+                            {recordActivity.error.message}
+                        </p>
+                    )}
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => setOpen(false)}
+                            disabled={recordActivity.isPending}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={recordActivity.isPending}>
+                            {recordActivity.isPending ? "Saving…" : "Save"}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/app/dashboard/_components/today-activity.tsx
+++ b/src/app/dashboard/_components/today-activity.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useMemo } from "react";
+import { Trash2 } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { api } from "~/trpc/react";
+
+export function TodayActivity({
+    petId,
+    petName,
+    canEdit = true,
+}: {
+    petId: number;
+    petName: string;
+    canEdit?: boolean;
+}) {
+    const { data, isLoading } = api.activity.getHistory.useQuery({ petId });
+    const utils = api.useUtils();
+    const deleteEntry = api.activity.deleteEntry.useMutation({
+        onSuccess: async () => {
+            await utils.activity.getHistory.invalidate({ petId });
+        },
+    });
+
+    const today = useMemo(() => {
+        if (!data) return [];
+        const start = new Date();
+        start.setHours(0, 0, 0, 0);
+        const end = new Date(start);
+        end.setDate(end.getDate() + 1);
+        return data.filter((row) => {
+            const t = row.performedAt.getTime();
+            return t >= start.getTime() && t < end.getTime();
+        });
+    }, [data]);
+
+    const totalMinutes = today.reduce((sum, r) => sum + r.durationMinutes, 0);
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                <div>
+                    <CardTitle>Today&apos;s activity</CardTitle>
+                    <CardDescription>
+                        {petName} · {today.length}{" "}
+                        {today.length === 1 ? "session" : "sessions"}
+                    </CardDescription>
+                </div>
+                <div className="text-right">
+                    <div className="text-2xl font-semibold">{totalMinutes}</div>
+                    <div className="text-xs text-muted-foreground">min today</div>
+                </div>
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <p className="text-sm text-muted-foreground">Loading…</p>
+                ) : today.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        No activity logged today yet.
+                    </p>
+                ) : (
+                    <ul className="space-y-2">
+                        {today.map((row) => (
+                            <li
+                                key={row.id}
+                                className="flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm"
+                            >
+                                <div className="min-w-0 flex-1">
+                                    <div className="truncate font-medium">
+                                        {row.activityType}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                        {row.performedAt.toLocaleTimeString([], {
+                                            hour: "numeric",
+                                            minute: "2-digit",
+                                        })}
+                                        {row.notes ? ` · ${row.notes}` : ""}
+                                    </div>
+                                </div>
+                                <div className="text-sm font-medium">
+                                    {row.durationMinutes} min
+                                </div>
+                                {canEdit && (
+                                    <Button
+                                        type="button"
+                                        size="icon"
+                                        variant="ghost"
+                                        disabled={deleteEntry.isPending}
+                                        onClick={() => {
+                                            if (!confirm("Delete this activity?")) return;
+                                            deleteEntry.mutate({ entryId: row.id });
+                                        }}
+                                        aria-label="Delete activity"
+                                        className="text-destructive hover:text-destructive"
+                                    >
+                                        <Trash2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/_components/weight-stats-card.tsx
+++ b/src/app/dashboard/_components/weight-stats-card.tsx
@@ -11,10 +11,8 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { cn } from "~/lib/utils";
+import { computeWeightStats } from "~/lib/weight-stats";
 import { api } from "~/trpc/react";
-import { type RouterOutputs } from "~/trpc/react";
-
-type Reading = RouterOutputs["weight"]["getWeightHistory"][number];
 
 export function WeightStatsCard({
     petId,
@@ -27,10 +25,10 @@ export function WeightStatsCard({
 }) {
     const { data, isLoading } = api.weight.getWeightHistory.useQuery({ petId });
 
-    const stats = useMemo(() => computeStats(data ?? [], goalWeight), [
-        data,
-        goalWeight,
-    ]);
+    const stats = useMemo(
+        () => computeWeightStats(data ?? [], goalWeight),
+        [data, goalWeight],
+    );
 
     return (
         <Card>
@@ -120,71 +118,3 @@ function DeltaStat({ label, delta }: { label: string; delta: number | null }) {
     );
 }
 
-function computeStats(rows: Reading[], goalWeight: number | null) {
-    if (rows.length === 0) return null;
-    const sorted = [...rows].sort(
-        (a, b) => a.weighedAt.getTime() - b.weighedAt.getTime(),
-    );
-    const latest = sorted[sorted.length - 1]!;
-    if (sorted.length === 1) {
-        return {
-            latest: latest.weight,
-            delta7: null as number | null,
-            delta30: null as number | null,
-            daysToGoal: null as number | null,
-            goalDate: null as Date | null,
-        };
-    }
-
-    const now = Date.now();
-    const findClosestBefore = (cutoffMs: number) => {
-        const candidate = [...sorted]
-            .reverse()
-            .find((r) => r.weighedAt.getTime() <= cutoffMs);
-        return candidate ?? sorted[0]!;
-    };
-    const ref7 = findClosestBefore(now - 7 * 86400000);
-    const ref30 = findClosestBefore(now - 30 * 86400000);
-    const delta7 =
-        ref7.id === latest.id ? null : latest.weight - ref7.weight;
-    const delta30 =
-        ref30.id === latest.id ? null : latest.weight - ref30.weight;
-
-    let daysToGoal: number | null = null;
-    let goalDate: Date | null = null;
-    if (goalWeight !== null) {
-        // Slope (weight per day) from the last 30 days of readings.
-        const cutoff = now - 30 * 86400000;
-        const recent = sorted.filter((r) => r.weighedAt.getTime() >= cutoff);
-        const span = recent.length >= 2 ? recent : sorted;
-        if (span.length >= 2) {
-            const first = span[0]!;
-            const last = span[span.length - 1]!;
-            const dwDays =
-                (last.weighedAt.getTime() - first.weighedAt.getTime()) /
-                86400000;
-            if (dwDays > 0) {
-                const slope = (last.weight - first.weight) / dwDays;
-                const remaining = goalWeight - latest.weight;
-                if (Math.sign(remaining) === Math.sign(slope) && slope !== 0) {
-                    const days = remaining / slope;
-                    daysToGoal = Math.round(days);
-                    goalDate = new Date(now + days * 86400000);
-                } else if (Math.abs(remaining) < 0.01) {
-                    daysToGoal = 0;
-                    goalDate = new Date();
-                } else {
-                    daysToGoal = -1;
-                }
-            }
-        }
-    }
-
-    return {
-        latest: latest.weight,
-        delta7,
-        delta30,
-        daysToGoal,
-        goalDate,
-    };
-}

--- a/src/app/dashboard/pets/[id]/_components/export-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/export-card.tsx
@@ -1,0 +1,37 @@
+import { Download } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+
+export function ExportCard({ petId }: { petId: number }) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Export</CardTitle>
+                <CardDescription>
+                    Download this pet&apos;s data as CSV.
+                </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-wrap gap-2">
+                <Button asChild variant="outline" size="sm">
+                    <a href={`/api/pets/${petId}/export?kind=weight`} download>
+                        <Download className="mr-2 h-3.5 w-3.5" />
+                        Weight CSV
+                    </a>
+                </Button>
+                <Button asChild variant="outline" size="sm">
+                    <a href={`/api/pets/${petId}/export?kind=feeding`} download>
+                        <Download className="mr-2 h-3.5 w-3.5" />
+                        Feeding CSV
+                    </a>
+                </Button>
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/pets/[id]/_components/health-events-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/health-events-card.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { HeartPulse, Plus, Trash2 } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "~/components/ui/dialog";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { api } from "~/trpc/react";
+
+const EVENT_TYPES = [
+    "Vet visit",
+    "Medication",
+    "Vaccination",
+    "Symptom",
+    "Surgery",
+    "Other",
+];
+
+export function HealthEventsCard({
+    petId,
+    canEdit,
+}: {
+    petId: number;
+    canEdit: boolean;
+}) {
+    const utils = api.useUtils();
+    const { data, isLoading } = api.health.getHistory.useQuery({ petId });
+    const [open, setOpen] = useState(false);
+    const [eventType, setEventType] = useState("Vet visit");
+    const [title, setTitle] = useState("");
+    const [occurredAt, setOccurredAt] = useState("");
+    const [notes, setNotes] = useState("");
+
+    const record = api.health.record.useMutation({
+        onSuccess: async () => {
+            await utils.health.getHistory.invalidate({ petId });
+            setOpen(false);
+            setTitle("");
+            setOccurredAt("");
+            setNotes("");
+        },
+    });
+    const deleteEntry = api.health.deleteEntry.useMutation({
+        onSuccess: async () => {
+            await utils.health.getHistory.invalidate({ petId });
+        },
+    });
+
+    function onSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        record.mutate({
+            petId,
+            eventType,
+            title: title.trim(),
+            ...(occurredAt ? { occurredAt: new Date(occurredAt) } : {}),
+            ...(notes.trim() ? { notes: notes.trim() } : {}),
+        });
+    }
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                <div>
+                    <CardTitle className="flex items-center gap-2">
+                        <HeartPulse className="h-4 w-4" />
+                        Health events
+                    </CardTitle>
+                    <CardDescription>
+                        Vet visits, medications, symptoms.
+                    </CardDescription>
+                </div>
+                {canEdit && (
+                    <Dialog open={open} onOpenChange={setOpen}>
+                        <DialogTrigger asChild>
+                            <Button type="button" size="sm" variant="outline">
+                                <Plus className="mr-1 h-3.5 w-3.5" />
+                                Add event
+                            </Button>
+                        </DialogTrigger>
+                        <DialogContent>
+                            <DialogHeader>
+                                <DialogTitle>Add health event</DialogTitle>
+                            </DialogHeader>
+                            <form onSubmit={onSubmit} className="space-y-3">
+                                <div className="space-y-1">
+                                    <Label htmlFor="he-type">Type</Label>
+                                    <select
+                                        id="he-type"
+                                        value={eventType}
+                                        onChange={(e) => setEventType(e.target.value)}
+                                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                                    >
+                                        {EVENT_TYPES.map((t) => (
+                                            <option key={t} value={t}>
+                                                {t}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                                <div className="space-y-1">
+                                    <Label htmlFor="he-title">Title</Label>
+                                    <Input
+                                        id="he-title"
+                                        required
+                                        value={title}
+                                        onChange={(e) => setTitle(e.target.value)}
+                                        placeholder="Annual checkup"
+                                    />
+                                </div>
+                                <div className="space-y-1">
+                                    <Label htmlFor="he-when">When</Label>
+                                    <Input
+                                        id="he-when"
+                                        type="datetime-local"
+                                        value={occurredAt}
+                                        onChange={(e) => setOccurredAt(e.target.value)}
+                                        max={new Date().toISOString().slice(0, 16)}
+                                    />
+                                </div>
+                                <div className="space-y-1">
+                                    <Label htmlFor="he-notes">Notes</Label>
+                                    <Input
+                                        id="he-notes"
+                                        value={notes}
+                                        onChange={(e) => setNotes(e.target.value)}
+                                        placeholder="All clear, next visit in 6 months"
+                                    />
+                                </div>
+                                {record.error && (
+                                    <p className="text-sm text-destructive">
+                                        {record.error.message}
+                                    </p>
+                                )}
+                                <DialogFooter>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={() => setOpen(false)}
+                                        disabled={record.isPending}
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button type="submit" disabled={record.isPending}>
+                                        {record.isPending ? "Saving…" : "Save"}
+                                    </Button>
+                                </DialogFooter>
+                            </form>
+                        </DialogContent>
+                    </Dialog>
+                )}
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <p className="text-sm text-muted-foreground">Loading…</p>
+                ) : !data || data.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        No health events logged yet.
+                    </p>
+                ) : (
+                    <ul className="divide-y">
+                        {data.map((row) => (
+                            <li
+                                key={row.id}
+                                className="flex items-start justify-between gap-3 py-3 text-sm"
+                            >
+                                <div className="min-w-0 flex-1">
+                                    <div className="flex items-baseline gap-2">
+                                        <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">
+                                            {row.eventType}
+                                        </span>
+                                        <span className="font-medium">{row.title}</span>
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">
+                                        {row.occurredAt.toLocaleString()}
+                                    </div>
+                                    {row.notes && (
+                                        <p className="mt-1 text-xs">{row.notes}</p>
+                                    )}
+                                </div>
+                                {canEdit && (
+                                    <Button
+                                        type="button"
+                                        size="icon"
+                                        variant="ghost"
+                                        disabled={deleteEntry.isPending}
+                                        onClick={() => {
+                                            if (!confirm("Delete this event?")) return;
+                                            deleteEntry.mutate({ entryId: row.id });
+                                        }}
+                                        aria-label="Delete event"
+                                        className="text-destructive hover:text-destructive"
+                                    >
+                                        <Trash2 className="h-3.5 w-3.5" />
+                                    </Button>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -8,6 +8,7 @@ import { PetEditCard } from "~/app/dashboard/pets/[id]/_components/pet-edit-card
 import { FeedingHistoryList } from "~/app/dashboard/pets/[id]/_components/feeding-history-list";
 import { WeightHistoryList } from "~/app/dashboard/pets/[id]/_components/weight-history-list";
 import { ExportCard } from "~/app/dashboard/pets/[id]/_components/export-card";
+import { HealthEventsCard } from "~/app/dashboard/pets/[id]/_components/health-events-card";
 import { DeletePetCard } from "~/app/dashboard/pets/[id]/_components/delete-pet-card";
 import { PetAlerts } from "~/app/dashboard/_components/pet-alerts";
 import { WeightChart } from "~/app/dashboard/_components/weight-chart";
@@ -55,6 +56,7 @@ export default async function PetDetailPage({
             />
             <WeightHistoryList petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <FeedingHistoryList petId={pet.id} canEdit={pet.role !== "Viewer"} />
+            <HealthEventsCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <ExportCard petId={pet.id} />
             <DeletePetCard petId={pet.id} petName={pet.name} role={pet.role} />
         </div>

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "~/components/ui/button";
 import { PetEditCard } from "~/app/dashboard/pets/[id]/_components/pet-edit-card";
 import { FeedingHistoryList } from "~/app/dashboard/pets/[id]/_components/feeding-history-list";
 import { WeightHistoryList } from "~/app/dashboard/pets/[id]/_components/weight-history-list";
+import { ExportCard } from "~/app/dashboard/pets/[id]/_components/export-card";
 import { DeletePetCard } from "~/app/dashboard/pets/[id]/_components/delete-pet-card";
 import { PetAlerts } from "~/app/dashboard/_components/pet-alerts";
 import { WeightChart } from "~/app/dashboard/_components/weight-chart";
@@ -54,6 +55,7 @@ export default async function PetDetailPage({
             />
             <WeightHistoryList petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <FeedingHistoryList petId={pet.id} canEdit={pet.role !== "Viewer"} />
+            <ExportCard petId={pet.id} />
             <DeletePetCard petId={pet.id} petName={pet.name} role={pet.role} />
         </div>
     );

--- a/src/lib/csv.test.ts
+++ b/src/lib/csv.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { csvEscape, toCsv } from "./csv";
+
+describe("csvEscape", () => {
+    it("returns empty string for null and undefined", () => {
+        expect(csvEscape(null)).toBe("");
+        expect(csvEscape(undefined)).toBe("");
+    });
+
+    it("passes through plain strings unchanged", () => {
+        expect(csvEscape("hello")).toBe("hello");
+        expect(csvEscape("with spaces")).toBe("with spaces");
+    });
+
+    it("quotes strings containing commas", () => {
+        expect(csvEscape("a, b")).toBe('"a, b"');
+    });
+
+    it("quotes and escapes inner double quotes", () => {
+        expect(csvEscape('she said "hi"')).toBe('"she said ""hi"""');
+    });
+
+    it("quotes strings containing newlines", () => {
+        expect(csvEscape("line1\nline2")).toBe('"line1\nline2"');
+    });
+
+    it("stringifies numbers without quoting", () => {
+        expect(csvEscape(42)).toBe("42");
+        expect(csvEscape(3.14)).toBe("3.14");
+    });
+});
+
+describe("toCsv", () => {
+    it("emits a trailing newline", () => {
+        expect(toCsv([["a", "b"]])).toBe("a,b\n");
+    });
+
+    it("joins rows with newlines and cells with commas", () => {
+        expect(
+            toCsv([
+                ["h1", "h2"],
+                [1, 2],
+                [3, 4],
+            ]),
+        ).toBe("h1,h2\n1,2\n3,4\n");
+    });
+
+    it("escapes per-cell as it goes", () => {
+        expect(toCsv([["name", "note"], ["a", "x,y"]])).toBe(
+            'name,note\na,"x,y"\n',
+        );
+    });
+});

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,12 @@
+export function csvEscape(value: unknown): string {
+    if (value === null || value === undefined) return "";
+    const s = String(value);
+    if (s.includes(",") || s.includes('"') || s.includes("\n")) {
+        return `"${s.replace(/"/g, '""')}"`;
+    }
+    return s;
+}
+
+export function toCsv(rows: ReadonlyArray<ReadonlyArray<unknown>>): string {
+    return rows.map((r) => r.map(csvEscape).join(",")).join("\n") + "\n";
+}

--- a/src/lib/weight-stats.test.ts
+++ b/src/lib/weight-stats.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { computeWeightStats, type WeightReading } from "./weight-stats";
+
+const day = 86_400_000;
+const now = new Date("2026-05-13T12:00:00Z").getTime();
+
+function r(
+    id: number,
+    weight: number,
+    daysAgo: number,
+): WeightReading {
+    return { id, weight, weighedAt: new Date(now - daysAgo * day) };
+}
+
+describe("computeWeightStats", () => {
+    it("returns null when there are no readings", () => {
+        expect(computeWeightStats([], null, now)).toBeNull();
+    });
+
+    it("returns latest only with nulls when there is one reading", () => {
+        const out = computeWeightStats([r(1, 5, 0)], 4, now);
+        expect(out).toEqual({
+            latest: 5,
+            delta7: null,
+            delta30: null,
+            daysToGoal: null,
+            goalDate: null,
+        });
+    });
+
+    it("computes deltas vs the closest reading before each cutoff", () => {
+        const out = computeWeightStats(
+            [r(1, 5.0, 60), r(2, 5.4, 30), r(3, 5.2, 10), r(4, 5.0, 0)],
+            null,
+            now,
+        );
+        expect(out).not.toBeNull();
+        // 7d delta: now(5.0) - ref(<=7d ago closest is 10d 5.2) = -0.2
+        expect(out!.delta7).toBeCloseTo(-0.2, 5);
+        // 30d delta: now(5.0) - 30d-ago(5.4) = -0.4
+        expect(out!.delta30).toBeCloseTo(-0.4, 5);
+        expect(out!.latest).toBeCloseTo(5.0, 5);
+        expect(out!.daysToGoal).toBeNull();
+    });
+
+    it("projects days to goal along the observed trend", () => {
+        // 30 days of linear loss: 6.0 -> 5.4 over 30d, so slope -0.02/day.
+        const rows = [r(1, 6.0, 30), r(2, 5.4, 0)];
+        const out = computeWeightStats(rows, 5.0, now);
+        expect(out).not.toBeNull();
+        // remaining = -0.4, slope = -0.02 => 20 days.
+        expect(out!.daysToGoal).toBe(20);
+        expect(out!.goalDate).toBeInstanceOf(Date);
+    });
+
+    it("marks unreachable when trend moves away from the goal", () => {
+        const rows = [r(1, 5.0, 30), r(2, 5.4, 0)]; // gaining
+        const out = computeWeightStats(rows, 4.5, now); // want to lose
+        expect(out!.daysToGoal).toBe(-1);
+    });
+
+    it("returns 0 days when already at goal", () => {
+        const rows = [r(1, 5.0, 30), r(2, 5.0, 0)];
+        const out = computeWeightStats(rows, 5.0, now);
+        expect(out!.daysToGoal).toBe(0);
+    });
+});

--- a/src/lib/weight-stats.ts
+++ b/src/lib/weight-stats.ts
@@ -1,0 +1,82 @@
+export type WeightReading = {
+    id: number;
+    weight: number;
+    weighedAt: Date;
+};
+
+export type WeightStats = {
+    latest: number;
+    delta7: number | null;
+    delta30: number | null;
+    daysToGoal: number | null;
+    goalDate: Date | null;
+};
+
+/**
+ * Pure stats calculation from a list of weight readings.
+ * Returns null when there are zero readings. `now` is injectable for tests.
+ */
+export function computeWeightStats(
+    rows: ReadonlyArray<WeightReading>,
+    goalWeight: number | null,
+    now: number = Date.now(),
+): WeightStats | null {
+    if (rows.length === 0) return null;
+
+    const sorted = [...rows].sort(
+        (a, b) => a.weighedAt.getTime() - b.weighedAt.getTime(),
+    );
+    const latest = sorted[sorted.length - 1]!;
+
+    if (sorted.length === 1) {
+        return {
+            latest: latest.weight,
+            delta7: null,
+            delta30: null,
+            daysToGoal: null,
+            goalDate: null,
+        };
+    }
+
+    const findClosestBefore = (cutoffMs: number): WeightReading =>
+        [...sorted]
+            .reverse()
+            .find((r) => r.weighedAt.getTime() <= cutoffMs) ?? sorted[0]!;
+
+    const ref7 = findClosestBefore(now - 7 * 86_400_000);
+    const ref30 = findClosestBefore(now - 30 * 86_400_000);
+    const delta7 = ref7.id === latest.id ? null : latest.weight - ref7.weight;
+    const delta30 =
+        ref30.id === latest.id ? null : latest.weight - ref30.weight;
+
+    let daysToGoal: number | null = null;
+    let goalDate: Date | null = null;
+    if (goalWeight !== null) {
+        const cutoff = now - 30 * 86_400_000;
+        const recent = sorted.filter((r) => r.weighedAt.getTime() >= cutoff);
+        const span = recent.length >= 2 ? recent : sorted;
+        if (span.length >= 2) {
+            const first = span[0]!;
+            const last = span[span.length - 1]!;
+            const dwDays =
+                (last.weighedAt.getTime() - first.weighedAt.getTime()) /
+                86_400_000;
+            if (dwDays > 0) {
+                const slope = (last.weight - first.weight) / dwDays;
+                const remaining = goalWeight - latest.weight;
+                if (Math.sign(remaining) === Math.sign(slope) && slope !== 0) {
+                    const days = remaining / slope;
+                    daysToGoal = Math.round(days);
+                    goalDate = new Date(now + days * 86_400_000);
+                } else if (Math.abs(remaining) < 0.01) {
+                    daysToGoal = 0;
+                    goalDate = new Date(now);
+                } else {
+                    daysToGoal = -1;
+                }
+            }
+        }
+    }
+
+    return { latest: latest.weight, delta7, delta30, daysToGoal, goalDate };
+}

--- a/src/schema/getActivityHistoryInput.ts
+++ b/src/schema/getActivityHistoryInput.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const getActivityHistoryInput = z.object({
+    petId: z.number().int().positive(),
+});

--- a/src/schema/recordActivityInput.ts
+++ b/src/schema/recordActivityInput.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const recordActivityInput = z.object({
+    petId: z.number().int().positive(),
+    activityType: z.string().min(1).max(64),
+    durationMinutes: z.number().int().positive(),
+    performedAt: z.date().optional(),
+    notes: z.string().max(1024).optional(),
+});

--- a/src/schema/recordHealthEventInput.ts
+++ b/src/schema/recordHealthEventInput.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const recordHealthEventInput = z.object({
+    petId: z.number().int().positive(),
+    eventType: z.string().min(1).max(64),
+    title: z.string().min(1).max(256),
+    occurredAt: z.date().optional(),
+    notes: z.string().max(2048).optional(),
+});

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -3,6 +3,7 @@ import { petRouter } from "~/server/api/routers/pet";
 import { weightRouter } from "~/server/api/routers/weight";
 import { feedingRouter } from "~/server/api/routers/feeding";
 import { foodRouter } from "~/server/api/routers/food";
+import { activityRouter } from "~/server/api/routers/activity";
 
 /**
  * This is the primary router for your server.
@@ -14,6 +15,7 @@ export const appRouter = createTRPCRouter({
   weight: weightRouter,
   feeding: feedingRouter,
   food: foodRouter,
+  activity: activityRouter,
 });
 
 // export type definition of API

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -4,6 +4,7 @@ import { weightRouter } from "~/server/api/routers/weight";
 import { feedingRouter } from "~/server/api/routers/feeding";
 import { foodRouter } from "~/server/api/routers/food";
 import { activityRouter } from "~/server/api/routers/activity";
+import { healthRouter } from "~/server/api/routers/health";
 
 /**
  * This is the primary router for your server.
@@ -16,6 +17,7 @@ export const appRouter = createTRPCRouter({
   feeding: feedingRouter,
   food: foodRouter,
   activity: activityRouter,
+  health: healthRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/activity.ts
+++ b/src/server/api/routers/activity.ts
@@ -1,0 +1,76 @@
+import { desc, eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { type db } from "~/server/db";
+import { activityHistory } from "~/server/db/schema";
+import { recordActivityInput } from "~/schema/recordActivityInput";
+import { getActivityHistoryInput } from "~/schema/getActivityHistoryInput";
+import { assertPetAccess } from "~/server/api/petAccess";
+import { z } from "zod";
+
+async function loadEntryPetId(
+    database: typeof db,
+    entryId: number,
+): Promise<number> {
+    const [row] = await database
+        .select({ petId: activityHistory.petId })
+        .from(activityHistory)
+        .where(eq(activityHistory.id, entryId))
+        .limit(1);
+    if (!row) {
+        throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Activity entry not found.",
+        });
+    }
+    return row.petId;
+}
+
+export const activityRouter = createTRPCRouter({
+    record: protectedProcedure
+        .input(recordActivityInput)
+        .mutation(async ({ ctx, input }) => {
+            await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            const [row] = await ctx.db
+                .insert(activityHistory)
+                .values({
+                    petId: input.petId,
+                    activityType: input.activityType,
+                    durationMinutes: input.durationMinutes,
+                    performedAt: input.performedAt ?? new Date(),
+                    notes: input.notes ?? null,
+                })
+                .returning();
+            if (!row) throw new Error("Failed to record activity.");
+            return row;
+        }),
+
+    getHistory: protectedProcedure
+        .input(getActivityHistoryInput)
+        .query(async ({ ctx, input }) => {
+            await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            return ctx.db
+                .select()
+                .from(activityHistory)
+                .where(eq(activityHistory.petId, input.petId))
+                .orderBy(desc(activityHistory.performedAt));
+        }),
+
+    deleteEntry: protectedProcedure
+        .input(z.object({ entryId: z.number().int().positive() }))
+        .mutation(async ({ ctx, input }) => {
+            const petId = await loadEntryPetId(ctx.db, input.entryId);
+            const role = await assertPetAccess(ctx.db, ctx.userId, petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot delete entries.",
+                });
+            }
+            await ctx.db
+                .delete(activityHistory)
+                .where(eq(activityHistory.id, input.entryId));
+            return { ok: true as const };
+        }),
+});

--- a/src/server/api/routers/health.ts
+++ b/src/server/api/routers/health.ts
@@ -1,0 +1,81 @@
+import { desc, eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { type db } from "~/server/db";
+import { healthEvents } from "~/server/db/schema";
+import { recordHealthEventInput } from "~/schema/recordHealthEventInput";
+import { assertPetAccess } from "~/server/api/petAccess";
+
+async function loadEntryPetId(
+    database: typeof db,
+    entryId: number,
+): Promise<number> {
+    const [row] = await database
+        .select({ petId: healthEvents.petId })
+        .from(healthEvents)
+        .where(eq(healthEvents.id, entryId))
+        .limit(1);
+    if (!row) {
+        throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Health event not found.",
+        });
+    }
+    return row.petId;
+}
+
+export const healthRouter = createTRPCRouter({
+    record: protectedProcedure
+        .input(recordHealthEventInput)
+        .mutation(async ({ ctx, input }) => {
+            const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot add health events.",
+                });
+            }
+            const [row] = await ctx.db
+                .insert(healthEvents)
+                .values({
+                    petId: input.petId,
+                    eventType: input.eventType,
+                    title: input.title,
+                    occurredAt: input.occurredAt ?? new Date(),
+                    notes: input.notes ?? null,
+                })
+                .returning();
+            if (!row) throw new Error("Failed to record health event.");
+            return row;
+        }),
+
+    getHistory: protectedProcedure
+        .input(z.object({ petId: z.number().int().positive() }))
+        .query(async ({ ctx, input }) => {
+            await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            return ctx.db
+                .select()
+                .from(healthEvents)
+                .where(eq(healthEvents.petId, input.petId))
+                .orderBy(desc(healthEvents.occurredAt));
+        }),
+
+    deleteEntry: protectedProcedure
+        .input(z.object({ entryId: z.number().int().positive() }))
+        .mutation(async ({ ctx, input }) => {
+            const petId = await loadEntryPetId(ctx.db, input.entryId);
+            const role = await assertPetAccess(ctx.db, ctx.userId, petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot delete entries.",
+                });
+            }
+            await ctx.db
+                .delete(healthEvents)
+                .where(eq(healthEvents.id, input.entryId));
+            return { ok: true as const };
+        }),
+});

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -115,3 +115,21 @@ export const eatingHistory = createTable(
         petIdx: index("eating_history_pet_id_idx").on(table.petId),
     }),
 );
+
+export const activityHistory = createTable(
+    "activity_history",
+    {
+        id: serial("id").primaryKey(),
+        petId: integer("pet_id")
+            .references(() => pets.id)
+            .notNull(),
+        activityType: varchar("activity_type", { length: 64 }).notNull(),
+        durationMinutes: integer("duration_minutes").notNull(),
+        performedAt: timestamp("performed_at", { withTimezone: true }).notNull(),
+        notes: varchar("notes", { length: 1024 }),
+        ...timestamps,
+    },
+    (table) => ({
+        petIdx: index("activity_history_pet_id_idx").on(table.petId),
+    }),
+);

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -133,3 +133,21 @@ export const activityHistory = createTable(
         petIdx: index("activity_history_pet_id_idx").on(table.petId),
     }),
 );
+
+export const healthEvents = createTable(
+    "health_events",
+    {
+        id: serial("id").primaryKey(),
+        petId: integer("pet_id")
+            .references(() => pets.id)
+            .notNull(),
+        eventType: varchar("event_type", { length: 64 }).notNull(),
+        title: varchar("title", { length: 256 }).notNull(),
+        occurredAt: timestamp("occurred_at", { withTimezone: true }).notNull(),
+        notes: varchar("notes", { length: 2048 }),
+        ...timestamps,
+    },
+    (table) => ({
+        petIdx: index("health_events_pet_id_idx").on(table.petId),
+    }),
+);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    resolve: {
+        alias: {
+            "~": path.resolve(__dirname, "src"),
+        },
+    },
+    test: {
+        environment: "node",
+        include: ["src/**/*.test.ts"],
+    },
+});


### PR DESCRIPTION
## Summary
S17. Per-pet CSV export.

### Route
`GET /api/pets/[id]/export?kind=weight|feeding`
- Clerk auth + `assertPetAccess` (401/403)
- Weight: `entry_id, weighed_at_iso, weight, created_at_iso`
- Feeding: `entry_id, fed_at_iso, food_name, food_brand, quantity_grams, calories_per_gram, computed_kcal, created_at_iso`
- Escapes commas/quotes/newlines
- Sets `Content-Type: text/csv; charset=utf-8` and a filename via `Content-Disposition`

### UI
- `ExportCard` on `/dashboard/pets/[id]` with two `<a download>` buttons

### Test plan
- [x] `pnpm typecheck` / `pnpm lint` clean
- [ ] Click "Weight CSV" / "Feeding CSV" → downloads the right file
- [ ] Try `/api/pets/<other-user-pet>/export?kind=weight` → 403
- [ ] Try `?kind=bogus` → 400

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_