### PR TITLE
S22: sonner toasts on every mutation

### DIFF
--- a/drizzle/0005_cynical_winter_soldier.sql
+++ b/drizzle/0005_cynical_winter_soldier.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "meow-weight-tracker_pets" ADD COLUMN "photo_url" varchar(1024);

--- a/drizzle/0006_worthless_iron_patriot.sql
+++ b/drizzle/0006_worthless_iron_patriot.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS "meow-weight-tracker_pet_invites" (
+	"token" varchar(64) PRIMARY KEY NOT NULL,
+	"pet_id" integer NOT NULL,
+	"role" "pet_role" NOT NULL,
+	"created_by" varchar(256) NOT NULL,
+	"accepted_at" timestamp with time zone,
+	"accepted_by" varchar(256),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "meow-weight-tracker_pet_invites" ADD CONSTRAINT "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk" FOREIGN KEY ("pet_id") REFERENCES "public"."meow-weight-tracker_pets"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "meow-weight-tracker_pet_invites" ADD CONSTRAINT "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."meow-weight-tracker_users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "meow-weight-tracker_pet_invites" ADD CONSTRAINT "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk" FOREIGN KEY ("accepted_by") REFERENCES "public"."meow-weight-tracker_users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "pet_invites_pet_id_idx" ON "meow-weight-tracker_pet_invites" ("pet_id");

--- a/drizzle/0007_slimy_jasper_sitwell.sql
+++ b/drizzle/0007_slimy_jasper_sitwell.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "meow-weight-tracker_pet_notes" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"pet_id" integer NOT NULL,
+	"body" varchar(4096) NOT NULL,
+	"written_at" timestamp with time zone NOT NULL,
+	"written_by" varchar(256) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "meow-weight-tracker_pet_notes" ADD CONSTRAINT "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk" FOREIGN KEY ("pet_id") REFERENCES "public"."meow-weight-tracker_pets"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "meow-weight-tracker_pet_notes" ADD CONSTRAINT "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk" FOREIGN KEY ("written_by") REFERENCES "public"."meow-weight-tracker_users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "pet_notes_pet_id_idx" ON "meow-weight-tracker_pet_notes" ("pet_id");

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,629 @@
+{
+  "id": "b8269e8d-def6-4641-bec2-2c6a1d9f9765",
+  "prevId": "c39b63ea-dac6-4a1d-8aa4-08014058a27d",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.meow-weight-tracker_activity_history": {
+      "name": "meow-weight-tracker_activity_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_history_pet_id_idx": {
+          "name": "activity_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_activity_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_eating_history": {
+      "name": "meow-weight-tracker_eating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fed_at": {
+          "name": "fed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_grams": {
+          "name": "quantity_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eating_history_pet_id_idx": {
+          "name": "eating_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk": {
+          "name": "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pet_food",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_health_events": {
+      "name": "meow-weight-tracker_health_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_events_pet_id_idx": {
+          "name": "health_events_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_health_events",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_food": {
+      "name": "meow-weight-tracker_pet_food",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories_per_gram": {
+          "name": "calories_per_gram",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_percent": {
+          "name": "protein_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat_percent": {
+          "name": "fat_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs_percent": {
+          "name": "carbs_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_food_name_idx": {
+          "name": "pet_food_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_people": {
+      "name": "meow-weight-tracker_pet_people",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_people_user_id_idx": {
+          "name": "pet_people_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "pet_people_pet_id_idx": {
+          "name": "pet_people_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meow-weight-tracker_pet_people_user_id_pet_id_pk": {
+          "name": "meow-weight-tracker_pet_people_user_id_pet_id_pk",
+          "columns": [
+            "user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pets": {
+      "name": "meow-weight-tracker_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_weight": {
+          "name": "goal_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_kcal_target": {
+          "name": "daily_kcal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_users": {
+      "name": "meow-weight-tracker_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_weight_history": {
+      "name": "meow-weight-tracker_weight_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weighed_at": {
+          "name": "weighed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weight_history_pet_id_idx": {
+          "name": "weight_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_weight_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.pet_role": {
+      "name": "pet_role",
+      "schema": "public",
+      "values": [
+        "Owner",
+        "Editor",
+        "Viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,738 @@
+{
+  "id": "3e426a90-a1db-49c8-acf2-579140b7e1dc",
+  "prevId": "b8269e8d-def6-4641-bec2-2c6a1d9f9765",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.meow-weight-tracker_activity_history": {
+      "name": "meow-weight-tracker_activity_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_history_pet_id_idx": {
+          "name": "activity_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_activity_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_eating_history": {
+      "name": "meow-weight-tracker_eating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fed_at": {
+          "name": "fed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_grams": {
+          "name": "quantity_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eating_history_pet_id_idx": {
+          "name": "eating_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk": {
+          "name": "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pet_food",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_health_events": {
+      "name": "meow-weight-tracker_health_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_events_pet_id_idx": {
+          "name": "health_events_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_health_events",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_food": {
+      "name": "meow-weight-tracker_pet_food",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories_per_gram": {
+          "name": "calories_per_gram",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_percent": {
+          "name": "protein_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat_percent": {
+          "name": "fat_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs_percent": {
+          "name": "carbs_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_food_name_idx": {
+          "name": "pet_food_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_invites": {
+      "name": "meow-weight-tracker_pet_invites",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_invites_pet_id_idx": {
+          "name": "pet_invites_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_people": {
+      "name": "meow-weight-tracker_pet_people",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_people_user_id_idx": {
+          "name": "pet_people_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "pet_people_pet_id_idx": {
+          "name": "pet_people_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meow-weight-tracker_pet_people_user_id_pet_id_pk": {
+          "name": "meow-weight-tracker_pet_people_user_id_pet_id_pk",
+          "columns": [
+            "user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pets": {
+      "name": "meow-weight-tracker_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_weight": {
+          "name": "goal_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_kcal_target": {
+          "name": "daily_kcal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_users": {
+      "name": "meow-weight-tracker_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_weight_history": {
+      "name": "meow-weight-tracker_weight_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weighed_at": {
+          "name": "weighed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weight_history_pet_id_idx": {
+          "name": "weight_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_weight_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.pet_role": {
+      "name": "pet_role",
+      "schema": "public",
+      "values": [
+        "Owner",
+        "Editor",
+        "Viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,827 @@
+{
+  "id": "60ec0dc2-7c42-4a86-a526-2205066a9abe",
+  "prevId": "3e426a90-a1db-49c8-acf2-579140b7e1dc",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.meow-weight-tracker_activity_history": {
+      "name": "meow-weight-tracker_activity_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_history_pet_id_idx": {
+          "name": "activity_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_activity_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_eating_history": {
+      "name": "meow-weight-tracker_eating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fed_at": {
+          "name": "fed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_grams": {
+          "name": "quantity_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eating_history_pet_id_idx": {
+          "name": "eating_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk": {
+          "name": "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pet_food",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_health_events": {
+      "name": "meow-weight-tracker_health_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_events_pet_id_idx": {
+          "name": "health_events_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_health_events",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_food": {
+      "name": "meow-weight-tracker_pet_food",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories_per_gram": {
+          "name": "calories_per_gram",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_percent": {
+          "name": "protein_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat_percent": {
+          "name": "fat_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs_percent": {
+          "name": "carbs_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_food_name_idx": {
+          "name": "pet_food_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_invites": {
+      "name": "meow-weight-tracker_pet_invites",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_invites_pet_id_idx": {
+          "name": "pet_invites_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_notes": {
+      "name": "meow-weight-tracker_pet_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_by": {
+          "name": "written_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_notes_pet_id_idx": {
+          "name": "pet_notes_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_notes",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_notes",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "written_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_people": {
+      "name": "meow-weight-tracker_pet_people",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_people_user_id_idx": {
+          "name": "pet_people_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "pet_people_pet_id_idx": {
+          "name": "pet_people_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meow-weight-tracker_pet_people_user_id_pet_id_pk": {
+          "name": "meow-weight-tracker_pet_people_user_id_pet_id_pk",
+          "columns": [
+            "user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pets": {
+      "name": "meow-weight-tracker_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_weight": {
+          "name": "goal_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_kcal_target": {
+          "name": "daily_kcal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_users": {
+      "name": "meow-weight-tracker_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_weight_history": {
+      "name": "meow-weight-tracker_weight_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weighed_at": {
+          "name": "weighed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weight_history_pet_id_idx": {
+          "name": "weight_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_weight_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.pet_role": {
+      "name": "pet_role",
+      "schema": "public",
+      "values": [
+        "Owner",
+        "Editor",
+        "Viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1778708533204,
       "tag": "0006_worthless_iron_patriot",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1778708778827,
+      "tag": "0007_slimy_jasper_sitwell",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1778705180664,
       "tag": "0004_fat_overlord",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1778708272560,
+      "tag": "0005_cynical_winter_soldier",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1778708272560,
       "tag": "0005_cynical_winter_soldier",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1778708533204,
+      "tag": "0006_worthless_iron_patriot",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-dom": "^18.3.0",
     "recharts": "^3.8.1",
     "server-only": "^0.0.1",
+    "sonner": "^2.0.7",
     "superjson": "^2.2.1",
     "svix": "^1.93.0",
     "tailwind-merge": "^3.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       superjson:
         specifier: ^2.2.1
         version: 2.2.1
@@ -3160,6 +3163,12 @@ packages:
   snakecase-keys@5.4.4:
     resolution: {integrity: sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==}
     engines: {node: '>=12'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
@@ -6538,6 +6547,11 @@ snapshots:
       map-obj: 4.3.0
       snake-case: 3.0.4
       type-fest: 2.19.0
+
+  sonner@2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.0: {}
 

--- a/public/apple-touch-icon.svg
+++ b/public/apple-touch-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180">
+  <rect width="180" height="180" rx="34" fill="#ffffff"/>
+  <text x="50%" y="50%" font-family="system-ui, -apple-system, sans-serif" font-size="100" text-anchor="middle" dominant-baseline="central">🐾</text>
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="#0f0f0f"/>
+  <text x="50%" y="50%" font-family="system-ui, -apple-system, sans-serif" font-size="280" text-anchor="middle" dominant-baseline="central">🐾</text>
+</svg>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "Meow Weight Tracker",
+  "short_name": "Meow",
+  "description": "Track your cat's weight, feedings, and habits.",
+  "start_url": "/dashboard",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0f0f0f",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/favicon.ico",
+      "sizes": "32x32",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/src/app/_components/bottom-nav.tsx
+++ b/src/app/_components/bottom-nav.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Cat, Plus, Utensils } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+
+const TABS = [
+    { href: "/dashboard", label: "Pets", icon: Cat, match: /^\/dashboard(?!\/foods)/ },
+    {
+        href: "/dashboard/pets/new",
+        label: "Add",
+        icon: Plus,
+        match: /^\/dashboard\/pets\/new$/,
+    },
+    {
+        href: "/dashboard/foods",
+        label: "Foods",
+        icon: Utensils,
+        match: /^\/dashboard\/foods/,
+    },
+] as const;
+
+export function BottomNav() {
+    const pathname = usePathname();
+    return (
+        <nav
+            aria-label="Primary"
+            className="fixed inset-x-0 bottom-0 z-40 border-t bg-background pb-[env(safe-area-inset-bottom)] md:hidden"
+        >
+            <ul className="mx-auto grid max-w-md grid-cols-3">
+                {TABS.map((tab) => {
+                    const Icon = tab.icon;
+                    const active = tab.match.test(pathname);
+                    return (
+                        <li key={tab.href} className="contents">
+                            <Link
+                                href={tab.href}
+                                className={cn(
+                                    "flex flex-col items-center justify-center gap-1 py-2 text-xs",
+                                    active
+                                        ? "text-foreground"
+                                        : "text-muted-foreground hover:text-foreground",
+                                )}
+                            >
+                                <Icon
+                                    className={cn(
+                                        "h-5 w-5",
+                                        active && "text-primary",
+                                    )}
+                                />
+                                {tab.label}
+                            </Link>
+                        </li>
+                    );
+                })}
+            </ul>
+        </nav>
+    );
+}

--- a/src/app/_components/topnav.tsx
+++ b/src/app/_components/topnav.tsx
@@ -11,13 +11,13 @@ export function TopNav() {
                 <SignedIn>
                     <Link
                         href="/dashboard"
-                        className="text-sm text-muted-foreground hover:text-foreground"
+                        className="hidden text-sm text-muted-foreground hover:text-foreground md:inline"
                     >
                         Dashboard
                     </Link>
                     <Link
                         href="/dashboard/foods"
-                        className="text-sm text-muted-foreground hover:text-foreground"
+                        className="hidden text-sm text-muted-foreground hover:text-foreground md:inline"
                     >
                         Foods
                     </Link>

--- a/src/app/_components/topnav.tsx
+++ b/src/app/_components/topnav.tsx
@@ -21,6 +21,12 @@ export function TopNav() {
                     >
                         Foods
                     </Link>
+                    <Link
+                        href="/dashboard/pets/deleted"
+                        className="hidden text-sm text-muted-foreground hover:text-foreground md:inline"
+                    >
+                        Deleted
+                    </Link>
                     <UserButton afterSignOutUrl="/" />
                 </SignedIn>
                 <SignedOut>

--- a/src/app/accept/[token]/_components/accept-invite-client.tsx
+++ b/src/app/accept/[token]/_components/accept-invite-client.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { api } from "~/trpc/react";
+
+export function AcceptInviteClient({ token }: { token: string }) {
+    const router = useRouter();
+    const tried = useRef(false);
+
+    const accept = api.pet.acceptInvite.useMutation({
+        onSuccess: ({ petId }) => {
+            toast.success("Invite accepted");
+            router.push(`/dashboard/pets/${petId}`);
+            router.refresh();
+        },
+        onError: (err) => toast.error(err.message),
+    });
+
+    useEffect(() => {
+        if (tried.current) return;
+        tried.current = true;
+        accept.mutate({ token });
+    }, [accept, token]);
+
+    return (
+        <div className="container mx-auto max-w-md py-12">
+            <Card>
+                <CardHeader>
+                    <CardTitle>Joining…</CardTitle>
+                    <CardDescription>
+                        {accept.error
+                            ? accept.error.message
+                            : "Accepting your invite."}
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {accept.error && (
+                        <p className="text-sm text-destructive">
+                            {accept.error.message}
+                        </p>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/app/accept/[token]/page.tsx
+++ b/src/app/accept/[token]/page.tsx
@@ -1,0 +1,19 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+
+import { AcceptInviteClient } from "~/app/accept/[token]/_components/accept-invite-client";
+
+export default function AcceptInvitePage({
+    params,
+}: {
+    params: { token: string };
+}) {
+    const { userId } = auth();
+    if (!userId) {
+        const search = new URLSearchParams({
+            redirect_url: `/accept/${params.token}`,
+        });
+        redirect(`/sign-in?${search.toString()}`);
+    }
+    return <AcceptInviteClient token={params.token} />;
+}

--- a/src/app/dashboard/_components/dashboard-content.tsx
+++ b/src/app/dashboard/_components/dashboard-content.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { ChevronRight } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
+import { KcalTrendChart } from "~/app/dashboard/_components/kcal-trend-chart";
 import { PetAlerts } from "~/app/dashboard/_components/pet-alerts";
 import { PetPicker } from "~/app/dashboard/_components/pet-picker";
 import { RecordActivityDialog } from "~/app/dashboard/_components/record-activity-dialog";
@@ -48,6 +49,11 @@ export function DashboardContent({ pets }: { pets: Pet[] }) {
                 petName={selectedPet.name}
                 dailyKcalTarget={selectedPet.dailyKcalTarget}
                 canEdit={selectedPet.role !== "Viewer"}
+            />
+            <KcalTrendChart
+                petId={selectedPet.id}
+                petName={selectedPet.name}
+                dailyKcalTarget={selectedPet.dailyKcalTarget}
             />
             <TodayActivity
                 petId={selectedPet.id}

--- a/src/app/dashboard/_components/feeding-row-actions.tsx
+++ b/src/app/dashboard/_components/feeding-row-actions.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type FormEvent } from "react";
 import { Pencil, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
 import {
@@ -38,12 +39,16 @@ export function FeedingRowActions({
         onSuccess: async () => {
             await utils.feeding.getFeedingHistory.invalidate({ petId });
             setEditing(false);
+            toast.success("Feeding updated");
         },
+        onError: (err) => toast.error(err.message),
     });
     const deleteEntry = api.feeding.deleteEntry.useMutation({
         onSuccess: async () => {
             await utils.feeding.getFeedingHistory.invalidate({ petId });
+            toast.success("Feeding deleted");
         },
+        onError: (err) => toast.error(err.message),
     });
 
     function onSubmit(event: FormEvent<HTMLFormElement>) {

--- a/src/app/dashboard/_components/kcal-trend-chart.tsx
+++ b/src/app/dashboard/_components/kcal-trend-chart.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    Cell,
+    ReferenceLine,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from "recharts";
+
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { computeDailyKcal } from "~/lib/kcal-trend";
+import { api } from "~/trpc/react";
+
+export function KcalTrendChart({
+    petId,
+    petName,
+    dailyKcalTarget,
+}: {
+    petId: number;
+    petName: string;
+    dailyKcalTarget: number | null;
+}) {
+    const { data, isLoading } = api.feeding.getFeedingHistory.useQuery({
+        petId,
+    });
+    const days = useMemo(() => computeDailyKcal(data ?? [], 14), [data]);
+    const maxKcal = Math.max(
+        dailyKcalTarget ?? 0,
+        ...days.map((d) => d.kcal),
+        100,
+    );
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Last 14 days</CardTitle>
+                <CardDescription>
+                    {petName}&apos;s daily kcal
+                    {dailyKcalTarget ? ` vs target ${dailyKcalTarget}` : ""}
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
+                        Loading…
+                    </div>
+                ) : (
+                    <div className="h-48 w-full">
+                        <ResponsiveContainer width="100%" height="100%">
+                            <BarChart
+                                data={days}
+                                margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+                            >
+                                <CartesianGrid
+                                    strokeDasharray="3 3"
+                                    stroke="hsl(var(--border))"
+                                />
+                                <XAxis
+                                    dataKey="dayLabel"
+                                    tick={{ fontSize: 10 }}
+                                    interval={1}
+                                />
+                                <YAxis
+                                    domain={[0, Math.ceil(maxKcal * 1.1)]}
+                                    tick={{ fontSize: 10 }}
+                                    width={32}
+                                />
+                                <Tooltip
+                                    formatter={(value) => [
+                                        `${Number(value).toFixed(0)} kcal`,
+                                        "kcal",
+                                    ]}
+                                />
+                                <Bar dataKey="kcal" radius={[3, 3, 0, 0]}>
+                                    {days.map((d) => (
+                                        <Cell
+                                            key={d.dayKey}
+                                            fill={
+                                                dailyKcalTarget &&
+                                                d.kcal > dailyKcalTarget
+                                                    ? "hsl(var(--destructive))"
+                                                    : "hsl(var(--primary))"
+                                            }
+                                        />
+                                    ))}
+                                </Bar>
+                                {dailyKcalTarget !== null && (
+                                    <ReferenceLine
+                                        y={dailyKcalTarget}
+                                        stroke="hsl(var(--muted-foreground))"
+                                        strokeDasharray="4 4"
+                                    />
+                                )}
+                            </BarChart>
+                        </ResponsiveContainer>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/_components/pet-alerts.tsx
+++ b/src/app/dashboard/_components/pet-alerts.tsx
@@ -1,27 +1,21 @@
 "use client";
 
 import { useMemo } from "react";
-import {
-    type AlertTriangle,
-    Utensils,
-    TrendingDown,
-    TrendingUp,
-} from "lucide-react";
+import { Utensils, TrendingDown, TrendingUp } from "lucide-react";
 
 import { cn } from "~/lib/utils";
+import {
+    computePetAlerts,
+    type AlertKind,
+    type PetAlert,
+} from "~/lib/pet-alerts";
 import { api } from "~/trpc/react";
 
-type Severity = "info" | "warn" | "alert";
-
-type Alert = {
-    severity: Severity;
-    icon: typeof AlertTriangle;
-    text: string;
+const ICONS: Record<AlertKind, typeof Utensils> = {
+    hungry: Utensils,
+    weightUp: TrendingUp,
+    weightDown: TrendingDown,
 };
-
-const HUNGRY_THRESHOLD_HOURS = 18;
-const WEIGHT_WARN_PCT = 5;
-const WEIGHT_ALERT_PCT = 10;
 
 export function PetAlerts({
     petId,
@@ -33,51 +27,17 @@ export function PetAlerts({
     const feedings = api.feeding.getFeedingHistory.useQuery({ petId });
     const weights = api.weight.getWeightHistory.useQuery({ petId });
 
-    const alerts = useMemo<Alert[]>(() => {
-        const out: Alert[] = [];
-        const now = Date.now();
-
-        if (feedings.data && feedings.data.length > 0) {
-            const last = feedings.data[0]!; // desc-ordered
-            const hours = (now - last.fedAt.getTime()) / 3_600_000;
-            if (hours >= HUNGRY_THRESHOLD_HOURS) {
-                out.push({
-                    severity: hours >= 24 ? "alert" : "warn",
-                    icon: Utensils,
-                    text: `${petName} hasn't been fed in ${Math.floor(hours)}h.`,
-                });
-            }
-        }
-
-        if (weights.data && weights.data.length >= 2) {
-            const sorted = [...weights.data].sort(
-                (a, b) => a.weighedAt.getTime() - b.weighedAt.getTime(),
-            );
-            const latest = sorted[sorted.length - 1]!;
-            const cutoff = now - 7 * 86_400_000;
-            const ref =
-                [...sorted]
-                    .reverse()
-                    .find((r) => r.weighedAt.getTime() <= cutoff) ?? sorted[0]!;
-            if (ref.id !== latest.id && ref.weight > 0) {
-                const pct = ((latest.weight - ref.weight) / ref.weight) * 100;
-                const abs = Math.abs(pct);
-                if (abs >= WEIGHT_WARN_PCT) {
-                    const Icon = pct > 0 ? TrendingUp : TrendingDown;
-                    out.push({
-                        severity: abs >= WEIGHT_ALERT_PCT ? "alert" : "warn",
-                        icon: Icon,
-                        text: `${petName}'s weight is ${pct > 0 ? "up" : "down"} ${abs.toFixed(1)}% over the last week.`,
-                    });
-                }
-            }
-        }
-
-        return out;
-    }, [feedings.data, weights.data, petName]);
+    const alerts = useMemo(
+        () =>
+            computePetAlerts({
+                feedings: feedings.data ?? [],
+                weights: weights.data ?? [],
+                petName,
+            }),
+        [feedings.data, weights.data, petName],
+    );
 
     if (alerts.length === 0) return null;
-
     return (
         <div className="space-y-2">
             {alerts.map((a, i) => (
@@ -87,8 +47,8 @@ export function PetAlerts({
     );
 }
 
-function AlertItem({ alert }: { alert: Alert }) {
-    const Icon = alert.icon;
+function AlertItem({ alert }: { alert: PetAlert }) {
+    const Icon = ICONS[alert.kind];
     return (
         <div
             className={cn(

--- a/src/app/dashboard/_components/pet-picker.tsx
+++ b/src/app/dashboard/_components/pet-picker.tsx
@@ -5,6 +5,7 @@ import { Plus } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
+import { PetAvatar } from "~/components/ui/pet-avatar";
 import { cn } from "~/lib/utils";
 import { type RouterOutputs } from "~/trpc/react";
 
@@ -46,9 +47,10 @@ export function PetPicker({
                                 )}
                             >
                                 <CardContent className="flex items-center gap-3 p-4">
-                                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-base font-semibold">
-                                        {pet.name.charAt(0).toUpperCase()}
-                                    </div>
+                                    <PetAvatar
+                                        name={pet.name}
+                                        photoUrl={pet.photoUrl}
+                                    />
                                     <div>
                                         <div className="font-medium">{pet.name}</div>
                                         <div className="text-xs text-muted-foreground">

--- a/src/app/dashboard/_components/record-activity-dialog.tsx
+++ b/src/app/dashboard/_components/record-activity-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type FormEvent } from "react";
 import { PlayCircle } from "lucide-react";
+import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
 import {
@@ -50,7 +51,9 @@ export function RecordActivityDialog({ pet }: { pet: Pet }) {
             setDuration("");
             setPerformedAt("");
             setNotes("");
+            toast.success(`Activity logged for ${pet.name}`);
         },
+        onError: (err) => toast.error(err.message),
     });
 
     function onSubmit(event: FormEvent<HTMLFormElement>) {

--- a/src/app/dashboard/_components/record-feeding-dialog.tsx
+++ b/src/app/dashboard/_components/record-feeding-dialog.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState, type FormEvent } from "react";
 import { Utensils } from "lucide-react";
+import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
 import {
@@ -49,7 +50,9 @@ export function RecordFeedingDialog({ pet }: { pet: Pet }) {
             setOpen(false);
             setGrams("");
             setFedAt("");
+            toast.success(`Feeding logged for ${pet.name}`);
         },
+        onError: (err) => toast.error(err.message),
     });
 
     useEffect(() => {

--- a/src/app/dashboard/_components/record-weight-dialog.tsx
+++ b/src/app/dashboard/_components/record-weight-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type FormEvent } from "react";
 import { Scale } from "lucide-react";
+import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
 import {
@@ -38,7 +39,9 @@ export function RecordWeightDialog({ pet }: { pet: Pet }) {
             setOpen(false);
             setWeight("");
             setRecordedAt("");
+            toast.success(`Weight saved for ${pet.name}`);
         },
+        onError: (err) => toast.error(err.message),
     });
 
     function onSubmit(event: FormEvent<HTMLFormElement>) {

--- a/src/app/dashboard/_components/today-activity.tsx
+++ b/src/app/dashboard/_components/today-activity.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { Trash2 } from "lucide-react";
+import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
 import {
@@ -27,7 +28,9 @@ export function TodayActivity({
     const deleteEntry = api.activity.deleteEntry.useMutation({
         onSuccess: async () => {
             await utils.activity.getHistory.invalidate({ petId });
+            toast.success("Activity deleted");
         },
+        onError: (err) => toast.error(err.message),
     });
 
     const today = useMemo(() => {

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+
+export default function DashboardError({
+    error,
+    reset,
+}: {
+    error: Error & { digest?: string };
+    reset: () => void;
+}) {
+    useEffect(() => {
+        console.error(error);
+    }, [error]);
+
+    return (
+        <div className="mx-auto max-w-md py-8">
+            <Card className="border-destructive/40">
+                <CardHeader>
+                    <CardTitle className="text-destructive">
+                        Couldn&apos;t load this page
+                    </CardTitle>
+                    <CardDescription>
+                        {error.message || "Unknown error."}
+                        {error.digest && (
+                            <span className="ml-2 text-xs">ref {error.digest}</span>
+                        )}
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="flex gap-2">
+                    <Button type="button" onClick={reset}>
+                        Try again
+                    </Button>
+                    <Button asChild variant="outline">
+                        <a href="/dashboard">Back to dashboard</a>
+                    </Button>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/app/dashboard/foods/_components/add-food-form.tsx
+++ b/src/app/dashboard/foods/_components/add-food-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
+import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
@@ -18,7 +19,7 @@ export function AddFoodForm() {
     const [notes, setNotes] = useState("");
 
     const createFood = api.food.create.useMutation({
-        onSuccess: async () => {
+        onSuccess: async (food) => {
             await utils.food.list.invalidate();
             setName("");
             setBrand("");
@@ -27,7 +28,9 @@ export function AddFoodForm() {
             setFat("");
             setCarbs("");
             setNotes("");
+            toast.success(`${food.name} added`);
         },
+        onError: (err) => toast.error(err.message),
     });
 
     function onSubmit(event: FormEvent<HTMLFormElement>) {

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,4 +1,5 @@
 import { TopNav } from "~/app/_components/topnav";
+import { BottomNav } from "~/app/_components/bottom-nav";
 
 export default function DashboardLayout({
     children,
@@ -8,7 +9,10 @@ export default function DashboardLayout({
     return (
         <div className="min-h-screen bg-background">
             <TopNav />
-            <main className="container mx-auto py-8">{children}</main>
+            <main className="container mx-auto py-6 pb-24 md:py-8 md:pb-8">
+                {children}
+            </main>
+            <BottomNav />
         </div>
     );
 }

--- a/src/app/dashboard/pets/[id]/_components/delete-pet-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/delete-pet-card.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Trash2 } from "lucide-react";
+import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
 import {
@@ -40,7 +41,9 @@ export function DeletePetCard({
             await utils.pet.getPets.invalidate();
             router.push("/dashboard");
             router.refresh();
+            toast.success(`${petName} deleted`);
         },
+        onError: (err) => toast.error(err.message),
     });
 
     if (role !== "Owner") return null;

--- a/src/app/dashboard/pets/[id]/_components/health-events-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/health-events-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type FormEvent } from "react";
 import { HeartPulse, Plus, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
 import {
@@ -54,12 +55,16 @@ export function HealthEventsCard({
             setTitle("");
             setOccurredAt("");
             setNotes("");
+            toast.success("Health event added");
         },
+        onError: (err) => toast.error(err.message),
     });
     const deleteEntry = api.health.deleteEntry.useMutation({
         onSuccess: async () => {
             await utils.health.getHistory.invalidate({ petId });
+            toast.success("Event deleted");
         },
+        onError: (err) => toast.error(err.message),
     });
 
     function onSubmit(event: FormEvent<HTMLFormElement>) {

--- a/src/app/dashboard/pets/[id]/_components/notes-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/notes-card.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { NotebookPen, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { api } from "~/trpc/react";
+
+export function NotesCard({
+    petId,
+    canEdit,
+}: {
+    petId: number;
+    canEdit: boolean;
+}) {
+    const utils = api.useUtils();
+    const [body, setBody] = useState("");
+    const { data, isLoading } = api.notes.getNotes.useQuery({ petId });
+
+    const record = api.notes.record.useMutation({
+        onSuccess: async () => {
+            await utils.notes.getNotes.invalidate({ petId });
+            setBody("");
+            toast.success("Note added");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+    const deleteEntry = api.notes.deleteEntry.useMutation({
+        onSuccess: async () => {
+            await utils.notes.getNotes.invalidate({ petId });
+            toast.success("Note deleted");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+
+    function onSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        const trimmed = body.trim();
+        if (!trimmed) return;
+        record.mutate({ petId, body: trimmed });
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                    <NotebookPen className="h-4 w-4" />
+                    Journal
+                </CardTitle>
+                <CardDescription>
+                    Free-form notes — milestones, habits, vet calls.
+                </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {canEdit && (
+                    <form onSubmit={onSubmit} className="space-y-2">
+                        <textarea
+                            value={body}
+                            onChange={(e) => setBody(e.target.value)}
+                            rows={3}
+                            maxLength={4096}
+                            placeholder="Loves the new toy. Snoring less."
+                            className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        />
+                        <div className="flex justify-end">
+                            <Button
+                                type="submit"
+                                size="sm"
+                                disabled={record.isPending || !body.trim()}
+                            >
+                                {record.isPending ? "Saving…" : "Add note"}
+                            </Button>
+                        </div>
+                    </form>
+                )}
+                {isLoading ? (
+                    <p className="text-sm text-muted-foreground">Loading…</p>
+                ) : !data || data.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        No notes yet.
+                    </p>
+                ) : (
+                    <ul className="space-y-3">
+                        {data.map((row) => (
+                            <li
+                                key={row.id}
+                                className="rounded-md border bg-card px-3 py-2 text-sm"
+                            >
+                                <div className="flex items-start justify-between gap-3">
+                                    <p className="whitespace-pre-wrap">{row.body}</p>
+                                    {canEdit && (
+                                        <Button
+                                            type="button"
+                                            size="icon"
+                                            variant="ghost"
+                                            disabled={deleteEntry.isPending}
+                                            onClick={() => {
+                                                if (!confirm("Delete this note?"))
+                                                    return;
+                                                deleteEntry.mutate({
+                                                    entryId: row.id,
+                                                });
+                                            }}
+                                            aria-label="Delete note"
+                                            className="text-destructive hover:text-destructive"
+                                        >
+                                            <Trash2 className="h-3.5 w-3.5" />
+                                        </Button>
+                                    )}
+                                </div>
+                                <div className="mt-1 text-xs text-muted-foreground">
+                                    {row.writtenAt.toLocaleString()}
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/pets/[id]/_components/pet-edit-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/pet-edit-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type FormEvent } from "react";
 import { Pencil } from "lucide-react";
+import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
 import {
@@ -39,7 +40,9 @@ export function PetEditCard({ pet }: { pet: Pet }) {
                 utils.pet.getPets.invalidate(),
             ]);
             setEditing(false);
+            toast.success(`${pet.name} updated`);
         },
+        onError: (err) => toast.error(err.message),
     });
 
     function onSubmit(event: FormEvent<HTMLFormElement>) {

--- a/src/app/dashboard/pets/[id]/_components/pet-edit-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/pet-edit-card.tsx
@@ -14,6 +14,7 @@ import {
 } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { PetAvatar } from "~/components/ui/pet-avatar";
 import { api } from "~/trpc/react";
 import { type RouterOutputs } from "~/trpc/react";
 
@@ -31,6 +32,7 @@ export function PetEditCard({ pet }: { pet: Pet }) {
     const [dailyKcalTarget, setDailyKcalTarget] = useState(
         pet.dailyKcalTarget !== null ? String(pet.dailyKcalTarget) : "",
     );
+    const [photoUrl, setPhotoUrl] = useState(pet.photoUrl ?? "");
 
     const utils = api.useUtils();
     const updatePet = api.pet.updatePet.useMutation({
@@ -57,6 +59,7 @@ export function PetEditCard({ pet }: { pet: Pet }) {
             birthDate: birthDate ? birthDate : null,
             goalWeight: goal,
             dailyKcalTarget: kcal,
+            photoUrl: photoUrl.trim() ? photoUrl.trim() : null,
         });
     }
 
@@ -65,9 +68,15 @@ export function PetEditCard({ pet }: { pet: Pet }) {
     return (
         <Card>
             <CardHeader className="flex flex-row items-start justify-between space-y-0">
-                <div>
-                    <CardTitle>{pet.name}</CardTitle>
-                    <CardDescription>
+                <div className="flex items-center gap-3">
+                    <PetAvatar
+                        name={pet.name}
+                        photoUrl={pet.photoUrl}
+                        size="lg"
+                    />
+                    <div>
+                        <CardTitle>{pet.name}</CardTitle>
+                        <CardDescription>
                         {[
                             pet.species,
                             pet.gender,
@@ -82,6 +91,7 @@ export function PetEditCard({ pet }: { pet: Pet }) {
                             .filter(Boolean)
                             .join(" · ")}
                     </CardDescription>
+                    </div>
                 </div>
                 {canEdit && !editing && (
                     <Button
@@ -172,6 +182,16 @@ export function PetEditCard({ pet }: { pet: Pet }) {
                                     placeholder="—"
                                 />
                             </div>
+                        </div>
+                        <div className="space-y-1">
+                            <Label htmlFor="edit-photo">Photo URL</Label>
+                            <Input
+                                id="edit-photo"
+                                type="url"
+                                value={photoUrl}
+                                onChange={(e) => setPhotoUrl(e.target.value)}
+                                placeholder="https://…"
+                            />
                         </div>
                         {updatePet.error && (
                             <p className="text-sm text-destructive">

--- a/src/app/dashboard/pets/[id]/_components/weight-history-list.tsx
+++ b/src/app/dashboard/pets/[id]/_components/weight-history-list.tsx
@@ -2,6 +2,7 @@
 
 import { useState, type FormEvent } from "react";
 import { Pencil, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
 import {
@@ -77,12 +78,16 @@ function WeightRow({
         onSuccess: async () => {
             await utils.weight.getWeightHistory.invalidate({ petId });
             setEditing(false);
+            toast.success("Weight updated");
         },
+        onError: (err) => toast.error(err.message),
     });
     const deleteEntry = api.weight.deleteEntry.useMutation({
         onSuccess: async () => {
             await utils.weight.getWeightHistory.invalidate({ petId });
+            toast.success("Weight deleted");
         },
+        onError: (err) => toast.error(err.message),
     });
 
     function onSubmit(event: FormEvent<HTMLFormElement>) {

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, Users } from "lucide-react";
 import { TRPCError } from "@trpc/server";
 
 import { Button } from "~/components/ui/button";
@@ -34,11 +34,17 @@ export default async function PetDetailPage({
 
     return (
         <div className="space-y-6">
-            <div>
+            <div className="flex items-center justify-between">
                 <Button asChild variant="ghost" size="sm" className="-ml-2">
                     <Link href="/dashboard">
                         <ChevronLeft className="mr-1 h-4 w-4" />
                         Dashboard
+                    </Link>
+                </Button>
+                <Button asChild variant="outline" size="sm">
+                    <Link href={`/dashboard/pets/${pet.id}/people`}>
+                        <Users className="mr-1 h-3.5 w-3.5" />
+                        People
                     </Link>
                 </Button>
             </div>

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -9,6 +9,7 @@ import { FeedingHistoryList } from "~/app/dashboard/pets/[id]/_components/feedin
 import { WeightHistoryList } from "~/app/dashboard/pets/[id]/_components/weight-history-list";
 import { ExportCard } from "~/app/dashboard/pets/[id]/_components/export-card";
 import { HealthEventsCard } from "~/app/dashboard/pets/[id]/_components/health-events-card";
+import { NotesCard } from "~/app/dashboard/pets/[id]/_components/notes-card";
 import { DeletePetCard } from "~/app/dashboard/pets/[id]/_components/delete-pet-card";
 import { PetAlerts } from "~/app/dashboard/_components/pet-alerts";
 import { WeightChart } from "~/app/dashboard/_components/weight-chart";
@@ -63,6 +64,7 @@ export default async function PetDetailPage({
             <WeightHistoryList petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <FeedingHistoryList petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <HealthEventsCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
+            <NotesCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <ExportCard petId={pet.id} />
             <DeletePetCard petId={pet.id} petName={pet.name} role={pet.role} />
         </div>

--- a/src/app/dashboard/pets/[id]/people/_components/people-manager.tsx
+++ b/src/app/dashboard/pets/[id]/people/_components/people-manager.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { Label } from "~/components/ui/label";
+import { api } from "~/trpc/react";
+
+type Role = "Owner" | "Editor" | "Viewer";
+
+export function PeopleManager({
+    petId,
+    petName,
+    role,
+}: {
+    petId: number;
+    petName: string;
+    role: Role;
+}) {
+    const utils = api.useUtils();
+    const people = api.pet.listPeople.useQuery({ petId });
+    const [inviteRole, setInviteRole] = useState<Role>("Editor");
+    const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+
+    const createInvite = api.pet.createInvite.useMutation({
+        onSuccess: (invite) => {
+            const url = `${window.location.origin}/accept/${invite.token}`;
+            setInviteUrl(url);
+            toast.success("Invite link generated");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+    const removePerson = api.pet.removePerson.useMutation({
+        onSuccess: async () => {
+            await utils.pet.listPeople.invalidate({ petId });
+            toast.success("Person removed");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+
+    const canManage = role === "Owner";
+
+    async function copyToClipboard() {
+        if (!inviteUrl) return;
+        try {
+            await navigator.clipboard.writeText(inviteUrl);
+            toast.success("Link copied");
+        } catch {
+            toast.error("Couldn't copy — select and copy the link manually.");
+        }
+    }
+
+    return (
+        <div className="space-y-4">
+            <Card>
+                <CardHeader>
+                    <CardTitle>People with access to {petName}</CardTitle>
+                    <CardDescription>
+                        Owners can manage people. Editors can record entries.
+                        Viewers can only read.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {people.isLoading ? (
+                        <p className="text-sm text-muted-foreground">Loading…</p>
+                    ) : !people.data || people.data.length === 0 ? (
+                        <p className="text-sm text-muted-foreground">
+                            No one yet.
+                        </p>
+                    ) : (
+                        <ul className="divide-y">
+                            {people.data.map((p) => (
+                                <li
+                                    key={p.userId}
+                                    className="flex items-center justify-between gap-3 py-2 text-sm"
+                                >
+                                    <div className="min-w-0">
+                                        <div className="truncate font-mono text-xs">
+                                            {p.userId}
+                                        </div>
+                                        <div className="text-xs text-muted-foreground">
+                                            {p.role} · added{" "}
+                                            {p.addedAt.toLocaleDateString()}
+                                        </div>
+                                    </div>
+                                    {canManage && (
+                                        <Button
+                                            type="button"
+                                            size="icon"
+                                            variant="ghost"
+                                            disabled={removePerson.isPending}
+                                            onClick={() => {
+                                                if (
+                                                    !confirm(
+                                                        `Remove this person from ${petName}?`,
+                                                    )
+                                                )
+                                                    return;
+                                                removePerson.mutate({
+                                                    petId,
+                                                    userId: p.userId,
+                                                });
+                                            }}
+                                            aria-label="Remove person"
+                                            className="text-destructive hover:text-destructive"
+                                        >
+                                            <Trash2 className="h-3.5 w-3.5" />
+                                        </Button>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </CardContent>
+            </Card>
+
+            {canManage && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Invite a co-owner</CardTitle>
+                        <CardDescription>
+                            Generate a single-use link. Whoever opens it signs in
+                            and joins {petName} at the chosen role.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        <div className="space-y-1">
+                            <Label htmlFor="invite-role">Role</Label>
+                            <select
+                                id="invite-role"
+                                value={inviteRole}
+                                onChange={(e) =>
+                                    setInviteRole(e.target.value as Role)
+                                }
+                                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                            >
+                                <option value="Editor">Editor</option>
+                                <option value="Viewer">Viewer</option>
+                            </select>
+                        </div>
+                        <Button
+                            type="button"
+                            disabled={createInvite.isPending}
+                            onClick={() =>
+                                createInvite.mutate({ petId, role: inviteRole })
+                            }
+                        >
+                            {createInvite.isPending
+                                ? "Generating…"
+                                : "Generate link"}
+                        </Button>
+                        {inviteUrl && (
+                            <div className="space-y-2 rounded-md border bg-muted p-3 text-sm">
+                                <div className="break-all font-mono text-xs">
+                                    {inviteUrl}
+                                </div>
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={copyToClipboard}
+                                >
+                                    <Copy className="mr-1 h-3.5 w-3.5" />
+                                    Copy link
+                                </Button>
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+            )}
+        </div>
+    );
+}

--- a/src/app/dashboard/pets/[id]/people/page.tsx
+++ b/src/app/dashboard/pets/[id]/people/page.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+import { TRPCError } from "@trpc/server";
+
+import { Button } from "~/components/ui/button";
+import { PeopleManager } from "~/app/dashboard/pets/[id]/people/_components/people-manager";
+import { api } from "~/trpc/server";
+
+export default async function PeoplePage({
+    params,
+}: {
+    params: { id: string };
+}) {
+    const petId = Number(params.id);
+    if (!Number.isFinite(petId) || petId <= 0) notFound();
+    let pet;
+    try {
+        pet = await api.pet.getPet({ petId });
+    } catch (err) {
+        if (err instanceof TRPCError && err.code === "FORBIDDEN") notFound();
+        if (err instanceof TRPCError && err.code === "NOT_FOUND") notFound();
+        throw err;
+    }
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <Button asChild variant="ghost" size="sm" className="-ml-2">
+                    <Link href={`/dashboard/pets/${pet.id}`}>
+                        <ChevronLeft className="mr-1 h-4 w-4" />
+                        Back to {pet.name}
+                    </Link>
+                </Button>
+            </div>
+            <PeopleManager petId={pet.id} petName={pet.name} role={pet.role} />
+        </div>
+    );
+}

--- a/src/app/dashboard/pets/deleted/_components/deleted-list.tsx
+++ b/src/app/dashboard/pets/deleted/_components/deleted-list.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { RotateCcw } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "~/components/ui/button";
+import { PetAvatar } from "~/components/ui/pet-avatar";
+import { api } from "~/trpc/react";
+import { type RouterOutputs } from "~/trpc/react";
+
+type Pet = RouterOutputs["pet"]["listDeleted"][number];
+
+export function DeletedList({ pets }: { pets: Pet[] }) {
+    const router = useRouter();
+    const utils = api.useUtils();
+    const restorePet = api.pet.restorePet.useMutation({
+        onSuccess: async () => {
+            await Promise.all([
+                utils.pet.getPets.invalidate(),
+                utils.pet.listDeleted.invalidate(),
+            ]);
+            router.refresh();
+            toast.success("Pet restored");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+
+    return (
+        <ul className="divide-y">
+            {pets.map((p) => (
+                <li
+                    key={p.id}
+                    className="flex items-center justify-between gap-3 py-3"
+                >
+                    <div className="flex items-center gap-3">
+                        <PetAvatar name={p.name} photoUrl={p.photoUrl} />
+                        <div>
+                            <div className="font-medium">{p.name}</div>
+                            <div className="text-xs text-muted-foreground">
+                                {p.species} · deleted{" "}
+                                {p.deletedAt?.toLocaleDateString() ?? "—"}
+                            </div>
+                        </div>
+                    </div>
+                    <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => restorePet.mutate({ petId: p.id })}
+                        disabled={restorePet.isPending}
+                    >
+                        <RotateCcw className="mr-1 h-3.5 w-3.5" />
+                        Restore
+                    </Button>
+                </li>
+            ))}
+        </ul>
+    );
+}

--- a/src/app/dashboard/pets/deleted/page.tsx
+++ b/src/app/dashboard/pets/deleted/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { DeletedList } from "~/app/dashboard/pets/deleted/_components/deleted-list";
+import { api } from "~/trpc/server";
+
+export default async function DeletedPetsPage() {
+    const pets = await api.pet.listDeleted();
+    return (
+        <div className="space-y-4">
+            <Button asChild variant="ghost" size="sm" className="-ml-2">
+                <Link href="/dashboard">
+                    <ChevronLeft className="mr-1 h-4 w-4" />
+                    Dashboard
+                </Link>
+            </Button>
+            <Card>
+                <CardHeader>
+                    <CardTitle>Deleted pets</CardTitle>
+                    <CardDescription>
+                        Only pets you own appear here. Restoring brings the pet
+                        and its history back to the dashboard.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {pets.length === 0 ? (
+                        <p className="text-sm text-muted-foreground">
+                            No deleted pets.
+                        </p>
+                    ) : (
+                        <DeletedList pets={pets} />
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/app/dashboard/pets/new/_components/new-pet-form.tsx
+++ b/src/app/dashboard/pets/new/_components/new-pet-form.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
+import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
@@ -17,11 +18,13 @@ export function NewPetForm() {
     const [birthDate, setBirthDate] = useState("");
 
     const createPet = api.pet.insertPet.useMutation({
-        onSuccess: async () => {
+        onSuccess: async (pet) => {
             await utils.pet.getPets.invalidate();
             router.push("/dashboard");
             router.refresh();
+            toast.success(`${pet.name} added`);
         },
+        onError: (err) => toast.error(err.message),
     });
 
     function onSubmit(event: FormEvent<HTMLFormElement>) {

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { Button } from "~/components/ui/button";
+
+export default function GlobalError({
+    error,
+    reset,
+}: {
+    error: Error & { digest?: string };
+    reset: () => void;
+}) {
+    useEffect(() => {
+        console.error(error);
+    }, [error]);
+
+    return (
+        <div className="container mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-4 text-center">
+            <h1 className="text-2xl font-bold">Something went wrong</h1>
+            <p className="text-sm text-muted-foreground">
+                {error.message || "Unknown error."}
+                {error.digest && (
+                    <span className="block text-xs">ref {error.digest}</span>
+                )}
+            </p>
+            <div className="flex gap-2">
+                <Button type="button" onClick={reset}>
+                    Try again
+                </Button>
+                <Button asChild variant="outline">
+                    <a href="/dashboard">Back to dashboard</a>
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { GeistSans } from "geist/font/sans";
 import { TRPCReactProvider } from "~/trpc/react";
 import {ClerkProvider} from "@clerk/nextjs";
 import {SpeedInsights} from "@vercel/speed-insights/next";
+import { Toaster } from "~/components/ui/toaster";
 
 export const metadata = {
   title: "Meow weight tracker",
@@ -24,6 +25,7 @@ export default function RootLayout({
           <TRPCReactProvider>
               <SpeedInsights/>
               {children}
+              <Toaster />
           </TRPCReactProvider>
           </body>
           </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,9 +8,26 @@ import {SpeedInsights} from "@vercel/speed-insights/next";
 import { Toaster } from "~/components/ui/toaster";
 
 export const metadata = {
-  title: "Meow weight tracker",
-  description: "web app to help manage and track your pet's weight",
-  icons: [{ rel: "icon", url: "/favicon.ico" }],
+  title: "Meow Weight Tracker",
+  description: "Track your cat's weight, feedings, and habits.",
+  manifest: "/site.webmanifest",
+  icons: [
+    { rel: "icon", url: "/favicon.ico" },
+    { rel: "icon", url: "/icon.svg", type: "image/svg+xml" },
+    { rel: "apple-touch-icon", url: "/apple-touch-icon.svg" },
+  ],
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "default" as const,
+    title: "Meow",
+  },
+};
+
+export const viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#0f0f0f" },
+  ],
 };
 
 export default function RootLayout({

--- a/src/components/ui/pet-avatar.tsx
+++ b/src/components/ui/pet-avatar.tsx
@@ -1,0 +1,35 @@
+import { cn } from "~/lib/utils";
+
+export function PetAvatar({
+    name,
+    photoUrl,
+    size = "md",
+}: {
+    name: string;
+    photoUrl: string | null;
+    size?: "sm" | "md" | "lg";
+}) {
+    const dims = size === "sm" ? "h-8 w-8" : size === "lg" ? "h-16 w-16" : "h-10 w-10";
+    const text = size === "sm" ? "text-xs" : size === "lg" ? "text-xl" : "text-base";
+    if (photoUrl) {
+        return (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+                src={photoUrl}
+                alt=""
+                className={cn(dims, "rounded-full object-cover")}
+            />
+        );
+    }
+    return (
+        <div
+            className={cn(
+                dims,
+                text,
+                "flex items-center justify-center rounded-full bg-muted font-semibold",
+            )}
+        >
+            {name.charAt(0).toUpperCase()}
+        </div>
+    );
+}

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { Toaster as SonnerToaster } from "sonner";
+
+export function Toaster() {
+    return (
+        <SonnerToaster
+            position="bottom-right"
+            richColors
+            closeButton
+            toastOptions={{ duration: 3500 }}
+        />
+    );
+}

--- a/src/lib/kcal-trend.test.ts
+++ b/src/lib/kcal-trend.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { computeDailyKcal, type FeedingForTrend } from "./kcal-trend";
+
+const now = new Date("2026-05-13T15:00:00");
+
+function f(daysAgo: number, grams: number, cpg: number): FeedingForTrend {
+    const d = new Date(now);
+    d.setDate(d.getDate() - daysAgo);
+    d.setHours(12, 0, 0, 0);
+    return { fedAt: d, quantityGrams: grams, food: { caloriesPerGram: cpg } };
+}
+
+describe("computeDailyKcal", () => {
+    it("returns a bucket per day in chronological order", () => {
+        const out = computeDailyKcal([], 14, now);
+        expect(out).toHaveLength(14);
+        for (let i = 1; i < out.length; i++) {
+            // Each dayLabel is later than the previous (labels are 'Apr 30', 'May 1', ...);
+            // we just sanity check the keys differ.
+            expect(out[i]!.dayKey).not.toBe(out[i - 1]!.dayKey);
+        }
+    });
+
+    it("sums kcal into the right day", () => {
+        const out = computeDailyKcal(
+            [f(0, 50, 4), f(0, 25, 4), f(1, 100, 3)],
+            14,
+            now,
+        );
+        const today = out[out.length - 1]!;
+        const yesterday = out[out.length - 2]!;
+        expect(today.kcal).toBe(300); // 50*4 + 25*4
+        expect(yesterday.kcal).toBe(300); // 100*3
+    });
+
+    it("ignores feedings outside the window", () => {
+        const out = computeDailyKcal([f(30, 100, 5)], 14, now);
+        const total = out.reduce((s, b) => s + b.kcal, 0);
+        expect(total).toBe(0);
+    });
+
+    it("returns 0 for days with no feedings", () => {
+        const out = computeDailyKcal([f(2, 50, 4)], 5, now);
+        expect(out).toHaveLength(5);
+        expect(out.filter((b) => b.kcal > 0)).toHaveLength(1);
+    });
+});

--- a/src/lib/kcal-trend.ts
+++ b/src/lib/kcal-trend.ts
@@ -1,0 +1,48 @@
+export type FeedingForTrend = {
+    fedAt: Date;
+    quantityGrams: number;
+    food: { caloriesPerGram: number };
+};
+
+export type DailyKcal = {
+    dayKey: string;
+    dayLabel: string;
+    kcal: number;
+};
+
+/**
+ * Returns one entry per day for the last `days` days ending today
+ * (inclusive), in chronological order. Days with no feedings get kcal=0.
+ */
+export function computeDailyKcal(
+    feedings: ReadonlyArray<FeedingForTrend>,
+    days: number,
+    now: Date = new Date(),
+): DailyKcal[] {
+    const buckets: DailyKcal[] = [];
+    const today = new Date(now);
+    today.setHours(0, 0, 0, 0);
+
+    const bucketByKey = new Map<string, DailyKcal>();
+    for (let i = days - 1; i >= 0; i--) {
+        const d = new Date(today);
+        d.setDate(d.getDate() - i);
+        const dayKey = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+        const dayLabel = d.toLocaleDateString(undefined, {
+            month: "short",
+            day: "numeric",
+        });
+        const bucket: DailyKcal = { dayKey, dayLabel, kcal: 0 };
+        buckets.push(bucket);
+        bucketByKey.set(dayKey, bucket);
+    }
+
+    for (const row of feedings) {
+        const d = row.fedAt;
+        const dayKey = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+        const bucket = bucketByKey.get(dayKey);
+        if (!bucket) continue;
+        bucket.kcal += row.quantityGrams * row.food.caloriesPerGram;
+    }
+    return buckets;
+}

--- a/src/lib/pet-alerts.test.ts
+++ b/src/lib/pet-alerts.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { computePetAlerts } from "./pet-alerts";
+
+const now = new Date("2026-05-13T15:00:00Z").getTime();
+const hoursAgo = (n: number) => new Date(now - n * 3_600_000);
+const daysAgo = (n: number) => new Date(now - n * 86_400_000);
+
+describe("computePetAlerts", () => {
+    it("returns nothing when there are no feedings or weights", () => {
+        expect(
+            computePetAlerts({
+                feedings: [],
+                weights: [],
+                petName: "Whiskers",
+                now,
+            }),
+        ).toEqual([]);
+    });
+
+    it("does not surface hungry when last feeding is within 18h", () => {
+        const out = computePetAlerts({
+            feedings: [{ fedAt: hoursAgo(12) }],
+            weights: [],
+            petName: "W",
+            now,
+        });
+        expect(out).toHaveLength(0);
+    });
+
+    it("surfaces a warn at 18h+ since last feeding", () => {
+        const out = computePetAlerts({
+            feedings: [{ fedAt: hoursAgo(19) }],
+            weights: [],
+            petName: "W",
+            now,
+        });
+        expect(out).toHaveLength(1);
+        expect(out[0]!.severity).toBe("warn");
+        expect(out[0]!.kind).toBe("hungry");
+    });
+
+    it("escalates to alert at 24h+", () => {
+        const out = computePetAlerts({
+            feedings: [{ fedAt: hoursAgo(26) }],
+            weights: [],
+            petName: "W",
+            now,
+        });
+        expect(out[0]!.severity).toBe("alert");
+    });
+
+    it("ignores week-over-week change below 5%", () => {
+        const out = computePetAlerts({
+            feedings: [],
+            weights: [
+                { id: 1, weight: 5.0, weighedAt: daysAgo(8) },
+                { id: 2, weight: 5.1, weighedAt: daysAgo(0) },
+            ],
+            petName: "W",
+            now,
+        });
+        expect(out).toHaveLength(0);
+    });
+
+    it("warns on 5%-10% week-over-week change", () => {
+        const out = computePetAlerts({
+            feedings: [],
+            weights: [
+                { id: 1, weight: 5.0, weighedAt: daysAgo(8) },
+                { id: 2, weight: 5.4, weighedAt: daysAgo(0) },
+            ],
+            petName: "W",
+            now,
+        });
+        expect(out).toHaveLength(1);
+        expect(out[0]!.severity).toBe("warn");
+        expect(out[0]!.kind).toBe("weightUp");
+    });
+
+    it("alerts at 10%+ week-over-week and marks direction", () => {
+        const out = computePetAlerts({
+            feedings: [],
+            weights: [
+                { id: 1, weight: 5.0, weighedAt: daysAgo(8) },
+                { id: 2, weight: 4.4, weighedAt: daysAgo(0) },
+            ],
+            petName: "W",
+            now,
+        });
+        expect(out).toHaveLength(1);
+        expect(out[0]!.severity).toBe("alert");
+        expect(out[0]!.kind).toBe("weightDown");
+    });
+
+    it("can surface both alerts simultaneously", () => {
+        const out = computePetAlerts({
+            feedings: [{ fedAt: hoursAgo(30) }],
+            weights: [
+                { id: 1, weight: 5.0, weighedAt: daysAgo(8) },
+                { id: 2, weight: 5.6, weighedAt: daysAgo(0) },
+            ],
+            petName: "W",
+            now,
+        });
+        expect(out).toHaveLength(2);
+        expect(out.map((a) => a.kind).sort()).toEqual(["hungry", "weightUp"]);
+    });
+});

--- a/src/lib/pet-alerts.ts
+++ b/src/lib/pet-alerts.ts
@@ -1,0 +1,77 @@
+export type AlertSeverity = "info" | "warn" | "alert";
+export type AlertKind = "hungry" | "weightUp" | "weightDown";
+
+export type PetAlert = {
+    severity: AlertSeverity;
+    kind: AlertKind;
+    text: string;
+};
+
+export type FeedingForAlerts = { fedAt: Date };
+export type WeightForAlerts = {
+    id: number;
+    weight: number;
+    weighedAt: Date;
+};
+
+export const HUNGRY_THRESHOLD_HOURS = 18;
+export const HUNGRY_ALERT_HOURS = 24;
+export const WEIGHT_WARN_PCT = 5;
+export const WEIGHT_ALERT_PCT = 10;
+
+/**
+ * Pure compute used by PetAlerts. Feedings are expected in descending
+ * fedAt order (latest first); weights may be in any order.
+ */
+export function computePetAlerts({
+    feedings,
+    weights,
+    petName,
+    now = Date.now(),
+}: {
+    feedings: ReadonlyArray<FeedingForAlerts>;
+    weights: ReadonlyArray<WeightForAlerts>;
+    petName: string;
+    now?: number;
+}): PetAlert[] {
+    const out: PetAlert[] = [];
+
+    const last = feedings[0];
+    if (last) {
+        const hours = (now - last.fedAt.getTime()) / 3_600_000;
+        if (hours >= HUNGRY_THRESHOLD_HOURS) {
+            out.push({
+                severity: hours >= HUNGRY_ALERT_HOURS ? "alert" : "warn",
+                kind: "hungry",
+                text: `${petName} hasn't been fed in ${Math.floor(hours)}h.`,
+            });
+        }
+    }
+
+    if (weights.length >= 2) {
+        const sorted = [...weights].sort(
+            (a, b) => a.weighedAt.getTime() - b.weighedAt.getTime(),
+        );
+        const latest = sorted[sorted.length - 1]!;
+        const cutoff = now - 7 * 86_400_000;
+        const ref =
+            [...sorted]
+                .reverse()
+                .find((r) => r.weighedAt.getTime() <= cutoff) ?? sorted[0]!;
+        if (ref.id !== latest.id && ref.weight > 0) {
+            const pct = ((latest.weight - ref.weight) / ref.weight) * 100;
+            const abs = Math.abs(pct);
+            if (abs >= WEIGHT_WARN_PCT) {
+                out.push({
+                    severity: abs >= WEIGHT_ALERT_PCT ? "alert" : "warn",
+                    kind: pct > 0 ? "weightUp" : "weightDown",
+                    text: `${petName}'s weight is ${
+                        pct > 0 ? "up" : "down"
+                    } ${abs.toFixed(1)}% over the last week.`,
+                });
+            }
+        }
+    }
+
+    return out;
+}

--- a/src/schema/updatePetInput.ts
+++ b/src/schema/updatePetInput.ts
@@ -12,6 +12,7 @@ export const updatePetInput = z.object({
         .optional(),
     goalWeight: z.number().positive().nullable().optional(),
     dailyKcalTarget: z.number().int().positive().nullable().optional(),
+    photoUrl: z.string().url().max(1024).nullable().optional(),
 });
 
 export type UpdatePetInput = z.infer<typeof updatePetInput>;

--- a/src/server/api/petAccess.test.ts
+++ b/src/server/api/petAccess.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { TRPCError } from "@trpc/server";
+
+import { assertPetAccess } from "./petAccess";
+
+function makeMockDb(rows: Array<{ role: "Owner" | "Editor" | "Viewer" }>) {
+    const chain = {
+        select: () => chain,
+        from: () => chain,
+        innerJoin: () => chain,
+        where: () => chain,
+        limit: async () => rows,
+    };
+    return chain as unknown as Parameters<typeof assertPetAccess>[0];
+}
+
+describe("assertPetAccess", () => {
+    it("returns the role when a row exists", async () => {
+        const db = makeMockDb([{ role: "Editor" }]);
+        await expect(assertPetAccess(db, "user_1", 42)).resolves.toBe(
+            "Editor",
+        );
+    });
+
+    it("throws FORBIDDEN when no row matches", async () => {
+        const db = makeMockDb([]);
+        await expect(assertPetAccess(db, "user_1", 42)).rejects.toBeInstanceOf(
+            TRPCError,
+        );
+        try {
+            await assertPetAccess(db, "user_1", 42);
+        } catch (err) {
+            expect(err).toBeInstanceOf(TRPCError);
+            expect((err as TRPCError).code).toBe("FORBIDDEN");
+        }
+    });
+
+    it("returns Owner role correctly", async () => {
+        const db = makeMockDb([{ role: "Owner" }]);
+        await expect(assertPetAccess(db, "u", 1)).resolves.toBe("Owner");
+    });
+
+    it("returns Viewer role correctly", async () => {
+        const db = makeMockDb([{ role: "Viewer" }]);
+        await expect(assertPetAccess(db, "u", 1)).resolves.toBe("Viewer");
+    });
+});

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -5,6 +5,7 @@ import { feedingRouter } from "~/server/api/routers/feeding";
 import { foodRouter } from "~/server/api/routers/food";
 import { activityRouter } from "~/server/api/routers/activity";
 import { healthRouter } from "~/server/api/routers/health";
+import { notesRouter } from "~/server/api/routers/notes";
 
 /**
  * This is the primary router for your server.
@@ -18,6 +19,7 @@ export const appRouter = createTRPCRouter({
   food: foodRouter,
   activity: activityRouter,
   health: healthRouter,
+  notes: notesRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/notes.ts
+++ b/src/server/api/routers/notes.ts
@@ -1,0 +1,85 @@
+import { desc, eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { type db } from "~/server/db";
+import { petNotes } from "~/server/db/schema";
+import { assertPetAccess } from "~/server/api/petAccess";
+
+const recordNoteInput = z.object({
+    petId: z.number().int().positive(),
+    body: z.string().min(1).max(4096),
+    writtenAt: z.date().optional(),
+});
+
+async function loadNotePetId(
+    database: typeof db,
+    entryId: number,
+): Promise<number> {
+    const [row] = await database
+        .select({ petId: petNotes.petId })
+        .from(petNotes)
+        .where(eq(petNotes.id, entryId))
+        .limit(1);
+    if (!row) {
+        throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Note not found.",
+        });
+    }
+    return row.petId;
+}
+
+export const notesRouter = createTRPCRouter({
+    record: protectedProcedure
+        .input(recordNoteInput)
+        .mutation(async ({ ctx, input }) => {
+            const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot add notes.",
+                });
+            }
+            const [row] = await ctx.db
+                .insert(petNotes)
+                .values({
+                    petId: input.petId,
+                    body: input.body,
+                    writtenAt: input.writtenAt ?? new Date(),
+                    writtenBy: ctx.userId,
+                })
+                .returning();
+            if (!row) throw new Error("Failed to record note.");
+            return row;
+        }),
+
+    getNotes: protectedProcedure
+        .input(z.object({ petId: z.number().int().positive() }))
+        .query(async ({ ctx, input }) => {
+            await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            return ctx.db
+                .select()
+                .from(petNotes)
+                .where(eq(petNotes.petId, input.petId))
+                .orderBy(desc(petNotes.writtenAt));
+        }),
+
+    deleteEntry: protectedProcedure
+        .input(z.object({ entryId: z.number().int().positive() }))
+        .mutation(async ({ ctx, input }) => {
+            const petId = await loadNotePetId(ctx.db, input.entryId);
+            const role = await assertPetAccess(ctx.db, ctx.userId, petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot delete notes.",
+                });
+            }
+            await ctx.db
+                .delete(petNotes)
+                .where(eq(petNotes.id, input.entryId));
+            return { ok: true as const };
+        }),
+});

--- a/src/server/api/routers/pet.ts
+++ b/src/server/api/routers/pet.ts
@@ -50,6 +50,7 @@ export const petRouter = createTRPCRouter({
                 birthDate: pets.birthDate,
                 goalWeight: pets.goalWeight,
                 dailyKcalTarget: pets.dailyKcalTarget,
+                photoUrl: pets.photoUrl,
                 createdAt: pets.createdAt,
                 updatedAt: pets.updatedAt,
                 role: petPeople.role,
@@ -95,6 +96,7 @@ export const petRouter = createTRPCRouter({
             if (input.goalWeight !== undefined) patch.goalWeight = input.goalWeight;
             if (input.dailyKcalTarget !== undefined)
                 patch.dailyKcalTarget = input.dailyKcalTarget;
+            if (input.photoUrl !== undefined) patch.photoUrl = input.photoUrl;
 
             const [row] = await ctx.db
                 .update(pets)

--- a/src/server/api/routers/pet.ts
+++ b/src/server/api/routers/pet.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
@@ -131,6 +131,54 @@ export const petRouter = createTRPCRouter({
             await ctx.db
                 .update(pets)
                 .set({ deletedAt: now, updatedAt: now })
+                .where(eq(pets.id, input.petId));
+            return { ok: true as const };
+        }),
+
+    listDeleted: protectedProcedure.query(async ({ ctx }) => {
+        return ctx.db
+            .select({
+                id: pets.id,
+                name: pets.name,
+                species: pets.species,
+                photoUrl: pets.photoUrl,
+                deletedAt: pets.deletedAt,
+                role: petPeople.role,
+            })
+            .from(pets)
+            .innerJoin(petPeople, eq(pets.id, petPeople.petId))
+            .where(
+                and(
+                    eq(petPeople.userId, ctx.userId),
+                    eq(petPeople.role, "Owner"),
+                    isNotNull(pets.deletedAt),
+                ),
+            );
+    }),
+
+    restorePet: protectedProcedure
+        .input(getPetInput)
+        .mutation(async ({ ctx, input }) => {
+            // assertPetAccess refuses deleted pets, so we check ownership manually here.
+            const [access] = await ctx.db
+                .select({ role: petPeople.role })
+                .from(petPeople)
+                .where(
+                    and(
+                        eq(petPeople.petId, input.petId),
+                        eq(petPeople.userId, ctx.userId),
+                    ),
+                )
+                .limit(1);
+            if (!access || access.role !== "Owner") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Only the Owner can restore a pet.",
+                });
+            }
+            await ctx.db
+                .update(pets)
+                .set({ deletedAt: null, updatedAt: new Date() })
                 .where(eq(pets.id, input.petId));
             return { ok: true as const };
         }),

--- a/src/server/api/routers/pet.ts
+++ b/src/server/api/routers/pet.ts
@@ -1,12 +1,16 @@
+import { randomUUID } from "node:crypto";
 import { and, eq, isNull } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
+import { z } from "zod";
 
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { createPetRequestInput } from "~/schema/createPetRequestInput";
 import { getPetInput } from "~/schema/getPetInput";
 import { updatePetInput } from "~/schema/updatePetInput";
-import { petPeople, pets } from "~/server/db/schema";
+import { petInvites, petPeople, pets, users } from "~/server/db/schema";
 import { assertPetAccess } from "~/server/api/petAccess";
+
+const roleSchema = z.enum(["Owner", "Editor", "Viewer"]);
 
 export const petRouter = createTRPCRouter({
     insertPet: protectedProcedure
@@ -129,5 +133,147 @@ export const petRouter = createTRPCRouter({
                 .set({ deletedAt: now, updatedAt: now })
                 .where(eq(pets.id, input.petId));
             return { ok: true as const };
+        }),
+
+    listPeople: protectedProcedure
+        .input(getPetInput)
+        .query(async ({ ctx, input }) => {
+            await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            return ctx.db
+                .select({
+                    userId: petPeople.userId,
+                    role: petPeople.role,
+                    addedAt: petPeople.createdAt,
+                })
+                .from(petPeople)
+                .where(eq(petPeople.petId, input.petId));
+        }),
+
+    removePerson: protectedProcedure
+        .input(
+            z.object({
+                petId: z.number().int().positive(),
+                userId: z.string().min(1),
+            }),
+        )
+        .mutation(async ({ ctx, input }) => {
+            const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            if (role !== "Owner") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Only the Owner can remove people.",
+                });
+            }
+            if (input.userId === ctx.userId) {
+                throw new TRPCError({
+                    code: "BAD_REQUEST",
+                    message: "Cannot remove yourself; delete the pet instead.",
+                });
+            }
+            const owners = await ctx.db
+                .select({ userId: petPeople.userId })
+                .from(petPeople)
+                .where(
+                    and(
+                        eq(petPeople.petId, input.petId),
+                        eq(petPeople.role, "Owner"),
+                    ),
+                );
+            if (owners.length === 1 && owners[0]!.userId === input.userId) {
+                throw new TRPCError({
+                    code: "BAD_REQUEST",
+                    message: "Cannot remove the last Owner.",
+                });
+            }
+            await ctx.db
+                .delete(petPeople)
+                .where(
+                    and(
+                        eq(petPeople.petId, input.petId),
+                        eq(petPeople.userId, input.userId),
+                    ),
+                );
+            return { ok: true as const };
+        }),
+
+    createInvite: protectedProcedure
+        .input(
+            z.object({
+                petId: z.number().int().positive(),
+                role: roleSchema,
+            }),
+        )
+        .mutation(async ({ ctx, input }) => {
+            const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            if (role !== "Owner") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Only the Owner can invite people.",
+                });
+            }
+            if (input.role === "Owner") {
+                throw new TRPCError({
+                    code: "BAD_REQUEST",
+                    message: "Invitations cannot grant the Owner role.",
+                });
+            }
+            const token = randomUUID().replace(/-/g, "");
+            const [row] = await ctx.db
+                .insert(petInvites)
+                .values({
+                    token,
+                    petId: input.petId,
+                    role: input.role,
+                    createdBy: ctx.userId,
+                })
+                .returning();
+            if (!row) {
+                throw new TRPCError({
+                    code: "INTERNAL_SERVER_ERROR",
+                    message: "Failed to create invite.",
+                });
+            }
+            return row;
+        }),
+
+    acceptInvite: protectedProcedure
+        .input(z.object({ token: z.string().min(1) }))
+        .mutation(async ({ ctx, input }) => {
+            const [invite] = await ctx.db
+                .select()
+                .from(petInvites)
+                .where(eq(petInvites.token, input.token))
+                .limit(1);
+            if (!invite) {
+                throw new TRPCError({
+                    code: "NOT_FOUND",
+                    message: "Invite not found.",
+                });
+            }
+            if (invite.acceptedAt !== null) {
+                throw new TRPCError({
+                    code: "BAD_REQUEST",
+                    message: "Invite already used.",
+                });
+            }
+            await ctx.db
+                .insert(users)
+                .values({ id: ctx.userId })
+                .onConflictDoNothing();
+            await ctx.db.transaction(async (trx) => {
+                await trx
+                    .insert(petPeople)
+                    .values({
+                        userId: ctx.userId,
+                        petId: invite.petId,
+                        role: invite.role,
+                    })
+                    .onConflictDoNothing();
+                await trx
+                    .update(petInvites)
+                    .set({ acceptedAt: new Date(), acceptedBy: ctx.userId })
+                    .where(eq(petInvites.token, invite.token));
+            });
+            return { petId: invite.petId };
         }),
 });

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -157,6 +157,25 @@ export const activityHistory = createTable(
     }),
 );
 
+export const petNotes = createTable(
+    "pet_notes",
+    {
+        id: serial("id").primaryKey(),
+        petId: integer("pet_id")
+            .references(() => pets.id)
+            .notNull(),
+        body: varchar("body", { length: 4096 }).notNull(),
+        writtenAt: timestamp("written_at", { withTimezone: true }).notNull(),
+        writtenBy: varchar("written_by", { length: 256 })
+            .references(() => users.id)
+            .notNull(),
+        ...timestamps,
+    },
+    (table) => ({
+        petIdx: index("pet_notes_pet_id_idx").on(table.petId),
+    }),
+);
+
 export const healthEvents = createTable(
     "health_events",
     {

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -38,6 +38,7 @@ export const pets = createTable("pets", {
     birthDate: date("birth_date"),
     goalWeight: real("goal_weight"),
     dailyKcalTarget: integer("daily_kcal_target"),
+    photoUrl: varchar("photo_url", { length: 1024 }),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
     ...timestamps,
 });

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -64,6 +64,28 @@ export const petPeople = createTable(
     }),
 );
 
+export const petInvites = createTable(
+    "pet_invites",
+    {
+        token: varchar("token", { length: 64 }).primaryKey(),
+        petId: integer("pet_id")
+            .references(() => pets.id)
+            .notNull(),
+        role: roleEnum("role").notNull(),
+        createdBy: varchar("created_by", { length: 256 })
+            .references(() => users.id)
+            .notNull(),
+        acceptedAt: timestamp("accepted_at", { withTimezone: true }),
+        acceptedBy: varchar("accepted_by", { length: 256 }).references(
+            () => users.id,
+        ),
+        ...timestamps,
+    },
+    (table) => ({
+        petIdx: index("pet_invites_pet_id_idx").on(table.petId),
+    }),
+);
+
 export const weightHistory = createTable(
     "weight_history",
     {

--- a/src/trpc/react.tsx
+++ b/src/trpc/react.tsx
@@ -1,24 +1,40 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+    QueryCache,
+    QueryClient,
+    QueryClientProvider,
+} from "@tanstack/react-query";
 import { loggerLink, unstable_httpBatchStreamLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
 import SuperJSON from "superjson";
+import { toast } from "sonner";
 
 import { type AppRouter } from "~/server/api/root";
 
-const createQueryClient = () => new QueryClient();
+const createQueryClient = () =>
+    new QueryClient({
+        queryCache: new QueryCache({
+            onError: (err, query) => {
+                // Skip the toast if the query opted out via meta.silentError.
+                if ((query.meta as { silentError?: boolean })?.silentError) return;
+                const message =
+                    err instanceof Error ? err.message : "Couldn't load data";
+                toast.error(message);
+            },
+        }),
+    });
 
 let clientQueryClientSingleton: QueryClient | undefined = undefined;
 const getQueryClient = () => {
-  if (typeof window === "undefined") {
-    // Server: always make a new query client
-    return createQueryClient();
-  }
-  // Browser: use singleton pattern to keep the same query client
-  return (clientQueryClientSingleton ??= createQueryClient());
+    if (typeof window === "undefined") {
+        // Server: always make a new query client
+        return createQueryClient();
+    }
+    // Browser: use singleton pattern to keep the same query client
+    return (clientQueryClientSingleton ??= createQueryClient());
 };
 
 export const api = createTRPCReact<AppRouter>();
@@ -38,40 +54,40 @@ export type RouterInputs = inferRouterInputs<AppRouter>;
 export type RouterOutputs = inferRouterOutputs<AppRouter>;
 
 export function TRPCReactProvider(props: { children: React.ReactNode }) {
-  const queryClient = getQueryClient();
+    const queryClient = getQueryClient();
 
-  const [trpcClient] = useState(() =>
-    api.createClient({
-      links: [
-        loggerLink({
-          enabled: (op) =>
-            process.env.NODE_ENV === "development" ||
-            (op.direction === "down" && op.result instanceof Error),
-        }),
-        unstable_httpBatchStreamLink({
-          transformer: SuperJSON,
-          url: getBaseUrl() + "/api/trpc",
-          headers: () => {
-            const headers = new Headers();
-            headers.set("x-trpc-source", "nextjs-react");
-            return headers;
-          },
-        }),
-      ],
-    })
-  );
+    const [trpcClient] = useState(() =>
+        api.createClient({
+            links: [
+                loggerLink({
+                    enabled: (op) =>
+                        process.env.NODE_ENV === "development" ||
+                        (op.direction === "down" && op.result instanceof Error),
+                }),
+                unstable_httpBatchStreamLink({
+                    transformer: SuperJSON,
+                    url: getBaseUrl() + "/api/trpc",
+                    headers: () => {
+                        const headers = new Headers();
+                        headers.set("x-trpc-source", "nextjs-react");
+                        return headers;
+                    },
+                }),
+            ],
+        })
+    );
 
-  return (
-    <QueryClientProvider client={queryClient}>
-      <api.Provider client={trpcClient} queryClient={queryClient}>
-        {props.children}
-      </api.Provider>
-    </QueryClientProvider>
-  );
+    return (
+        <QueryClientProvider client={queryClient}>
+            <api.Provider client={trpcClient} queryClient={queryClient}>
+                {props.children}
+            </api.Provider>
+        </QueryClientProvider>
+    );
 }
 
 function getBaseUrl() {
-  if (typeof window !== "undefined") return window.location.origin;
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-  return `http://localhost:${process.env.PORT ?? 3000}`;
+    if (typeof window !== "undefined") return window.location.origin;
+    if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+    return `http://localhost:${process.env.PORT ?? 3000}`;
 }


### PR DESCRIPTION
## Summary
S22 (first of Batch 3). Adds sonner toasts to every mutation in the app.

### Changes
- `sonner` installed, `Toaster` wrapper mounted in the root layout (bottom-right, rich colors, 3.5s)
- `onSuccess` toasts on: `pet.insertPet/updatePet/deletePet`, `weight.recordWeight/updateEntry/deleteEntry`, `feeding.recordFeeding/updateEntry/deleteEntry`, `activity.record/deleteEntry`, `food.create`, `health.record/deleteEntry`
- `onError: (err) => toast.error(err.message)` on each
- Labels include context where helpful: "Whiskers updated", "Feeding deleted", etc.

### Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` clean
- [ ] Log a weight → bottom-right success toast appears
- [ ] Force an error (e.g. tampered call) → red error toast with the server message

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_