### PR TITLE
fix(ci): use corepack to resolve pnpm version mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
+      - name: Enable corepack (pnpm from packageManager field)
+        run: corepack enable
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
Quick fix for the CI failure on Batch 3 PRs (#35–#38).

### Root cause
`pnpm/action-setup@v4` with `version: 9` conflicts with `package.json`'s `packageManager: pnpm@9.0.1` field, failing the install step in ~5s before any code runs.

### Fix
Drop the `pnpm/action-setup` step and use `corepack enable` instead. `corepack` reads the `packageManager` field and installs the exact pnpm version. No version drift.

### Impact on existing Batch 3 PRs
PRs #35–#38 will keep failing CI until their branches are rebased on this fix (or it's merged into main and they're updated). After this merges to main, the rest of Batch 3 (S26 onward) will inherit the fix automatically.

### Test plan
- [x] No code changes outside the workflow
- [ ] CI on this PR itself runs cleanly end-to-end (typecheck + lint + test)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_