### PR TITLE
S29: PWA manifest + icons

### DIFF
--- a/public/apple-touch-icon.svg
+++ b/public/apple-touch-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180">
+  <rect width="180" height="180" rx="34" fill="#ffffff"/>
+  <text x="50%" y="50%" font-family="system-ui, -apple-system, sans-serif" font-size="100" text-anchor="middle" dominant-baseline="central">🐾</text>
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="#0f0f0f"/>
+  <text x="50%" y="50%" font-family="system-ui, -apple-system, sans-serif" font-size="280" text-anchor="middle" dominant-baseline="central">🐾</text>
+</svg>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "Meow Weight Tracker",
+  "short_name": "Meow",
+  "description": "Track your cat's weight, feedings, and habits.",
+  "start_url": "/dashboard",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0f0f0f",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/favicon.ico",
+      "sizes": "32x32",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/src/app/dashboard/_components/pet-alerts.tsx
+++ b/src/app/dashboard/_components/pet-alerts.tsx
@@ -1,27 +1,21 @@
 "use client";
 
 import { useMemo } from "react";
-import {
-    type AlertTriangle,
-    Utensils,
-    TrendingDown,
-    TrendingUp,
-} from "lucide-react";
+import { Utensils, TrendingDown, TrendingUp } from "lucide-react";
 
 import { cn } from "~/lib/utils";
+import {
+    computePetAlerts,
+    type AlertKind,
+    type PetAlert,
+} from "~/lib/pet-alerts";
 import { api } from "~/trpc/react";
 
-type Severity = "info" | "warn" | "alert";
-
-type Alert = {
-    severity: Severity;
-    icon: typeof AlertTriangle;
-    text: string;
+const ICONS: Record<AlertKind, typeof Utensils> = {
+    hungry: Utensils,
+    weightUp: TrendingUp,
+    weightDown: TrendingDown,
 };
-
-const HUNGRY_THRESHOLD_HOURS = 18;
-const WEIGHT_WARN_PCT = 5;
-const WEIGHT_ALERT_PCT = 10;
 
 export function PetAlerts({
     petId,
@@ -33,51 +27,17 @@ export function PetAlerts({
     const feedings = api.feeding.getFeedingHistory.useQuery({ petId });
     const weights = api.weight.getWeightHistory.useQuery({ petId });
 
-    const alerts = useMemo<Alert[]>(() => {
-        const out: Alert[] = [];
-        const now = Date.now();
-
-        if (feedings.data && feedings.data.length > 0) {
-            const last = feedings.data[0]!; // desc-ordered
-            const hours = (now - last.fedAt.getTime()) / 3_600_000;
-            if (hours >= HUNGRY_THRESHOLD_HOURS) {
-                out.push({
-                    severity: hours >= 24 ? "alert" : "warn",
-                    icon: Utensils,
-                    text: `${petName} hasn't been fed in ${Math.floor(hours)}h.`,
-                });
-            }
-        }
-
-        if (weights.data && weights.data.length >= 2) {
-            const sorted = [...weights.data].sort(
-                (a, b) => a.weighedAt.getTime() - b.weighedAt.getTime(),
-            );
-            const latest = sorted[sorted.length - 1]!;
-            const cutoff = now - 7 * 86_400_000;
-            const ref =
-                [...sorted]
-                    .reverse()
-                    .find((r) => r.weighedAt.getTime() <= cutoff) ?? sorted[0]!;
-            if (ref.id !== latest.id && ref.weight > 0) {
-                const pct = ((latest.weight - ref.weight) / ref.weight) * 100;
-                const abs = Math.abs(pct);
-                if (abs >= WEIGHT_WARN_PCT) {
-                    const Icon = pct > 0 ? TrendingUp : TrendingDown;
-                    out.push({
-                        severity: abs >= WEIGHT_ALERT_PCT ? "alert" : "warn",
-                        icon: Icon,
-                        text: `${petName}'s weight is ${pct > 0 ? "up" : "down"} ${abs.toFixed(1)}% over the last week.`,
-                    });
-                }
-            }
-        }
-
-        return out;
-    }, [feedings.data, weights.data, petName]);
+    const alerts = useMemo(
+        () =>
+            computePetAlerts({
+                feedings: feedings.data ?? [],
+                weights: weights.data ?? [],
+                petName,
+            }),
+        [feedings.data, weights.data, petName],
+    );
 
     if (alerts.length === 0) return null;
-
     return (
         <div className="space-y-2">
             {alerts.map((a, i) => (
@@ -87,8 +47,8 @@ export function PetAlerts({
     );
 }
 
-function AlertItem({ alert }: { alert: Alert }) {
-    const Icon = alert.icon;
+function AlertItem({ alert }: { alert: PetAlert }) {
+    const Icon = ICONS[alert.kind];
     return (
         <div
             className={cn(

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+
+export default function DashboardError({
+    error,
+    reset,
+}: {
+    error: Error & { digest?: string };
+    reset: () => void;
+}) {
+    useEffect(() => {
+        console.error(error);
+    }, [error]);
+
+    return (
+        <div className="mx-auto max-w-md py-8">
+            <Card className="border-destructive/40">
+                <CardHeader>
+                    <CardTitle className="text-destructive">
+                        Couldn&apos;t load this page
+                    </CardTitle>
+                    <CardDescription>
+                        {error.message || "Unknown error."}
+                        {error.digest && (
+                            <span className="ml-2 text-xs">ref {error.digest}</span>
+                        )}
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="flex gap-2">
+                    <Button type="button" onClick={reset}>
+                        Try again
+                    </Button>
+                    <Button asChild variant="outline">
+                        <a href="/dashboard">Back to dashboard</a>
+                    </Button>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { Button } from "~/components/ui/button";
+
+export default function GlobalError({
+    error,
+    reset,
+}: {
+    error: Error & { digest?: string };
+    reset: () => void;
+}) {
+    useEffect(() => {
+        console.error(error);
+    }, [error]);
+
+    return (
+        <div className="container mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-4 text-center">
+            <h1 className="text-2xl font-bold">Something went wrong</h1>
+            <p className="text-sm text-muted-foreground">
+                {error.message || "Unknown error."}
+                {error.digest && (
+                    <span className="block text-xs">ref {error.digest}</span>
+                )}
+            </p>
+            <div className="flex gap-2">
+                <Button type="button" onClick={reset}>
+                    Try again
+                </Button>
+                <Button asChild variant="outline">
+                    <a href="/dashboard">Back to dashboard</a>
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,9 +8,26 @@ import {SpeedInsights} from "@vercel/speed-insights/next";
 import { Toaster } from "~/components/ui/toaster";
 
 export const metadata = {
-  title: "Meow weight tracker",
-  description: "web app to help manage and track your pet's weight",
-  icons: [{ rel: "icon", url: "/favicon.ico" }],
+  title: "Meow Weight Tracker",
+  description: "Track your cat's weight, feedings, and habits.",
+  manifest: "/site.webmanifest",
+  icons: [
+    { rel: "icon", url: "/favicon.ico" },
+    { rel: "icon", url: "/icon.svg", type: "image/svg+xml" },
+    { rel: "apple-touch-icon", url: "/apple-touch-icon.svg" },
+  ],
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "default" as const,
+    title: "Meow",
+  },
+};
+
+export const viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#0f0f0f" },
+  ],
 };
 
 export default function RootLayout({

--- a/src/lib/pet-alerts.test.ts
+++ b/src/lib/pet-alerts.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { computePetAlerts } from "./pet-alerts";
+
+const now = new Date("2026-05-13T15:00:00Z").getTime();
+const hoursAgo = (n: number) => new Date(now - n * 3_600_000);
+const daysAgo = (n: number) => new Date(now - n * 86_400_000);
+
+describe("computePetAlerts", () => {
+    it("returns nothing when there are no feedings or weights", () => {
+        expect(
+            computePetAlerts({
+                feedings: [],
+                weights: [],
+                petName: "Whiskers",
+                now,
+            }),
+        ).toEqual([]);
+    });
+
+    it("does not surface hungry when last feeding is within 18h", () => {
+        const out = computePetAlerts({
+            feedings: [{ fedAt: hoursAgo(12) }],
+            weights: [],
+            petName: "W",
+            now,
+        });
+        expect(out).toHaveLength(0);
+    });
+
+    it("surfaces a warn at 18h+ since last feeding", () => {
+        const out = computePetAlerts({
+            feedings: [{ fedAt: hoursAgo(19) }],
+            weights: [],
+            petName: "W",
+            now,
+        });
+        expect(out).toHaveLength(1);
+        expect(out[0]!.severity).toBe("warn");
+        expect(out[0]!.kind).toBe("hungry");
+    });
+
+    it("escalates to alert at 24h+", () => {
+        const out = computePetAlerts({
+            feedings: [{ fedAt: hoursAgo(26) }],
+            weights: [],
+            petName: "W",
+            now,
+        });
+        expect(out[0]!.severity).toBe("alert");
+    });
+
+    it("ignores week-over-week change below 5%", () => {
+        const out = computePetAlerts({
+            feedings: [],
+            weights: [
+                { id: 1, weight: 5.0, weighedAt: daysAgo(8) },
+                { id: 2, weight: 5.1, weighedAt: daysAgo(0) },
+            ],
+            petName: "W",
+            now,
+        });
+        expect(out).toHaveLength(0);
+    });
+
+    it("warns on 5%-10% week-over-week change", () => {
+        const out = computePetAlerts({
+            feedings: [],
+            weights: [
+                { id: 1, weight: 5.0, weighedAt: daysAgo(8) },
+                { id: 2, weight: 5.4, weighedAt: daysAgo(0) },
+            ],
+            petName: "W",
+            now,
+        });
+        expect(out).toHaveLength(1);
+        expect(out[0]!.severity).toBe("warn");
+        expect(out[0]!.kind).toBe("weightUp");
+    });
+
+    it("alerts at 10%+ week-over-week and marks direction", () => {
+        const out = computePetAlerts({
+            feedings: [],
+            weights: [
+                { id: 1, weight: 5.0, weighedAt: daysAgo(8) },
+                { id: 2, weight: 4.4, weighedAt: daysAgo(0) },
+            ],
+            petName: "W",
+            now,
+        });
+        expect(out).toHaveLength(1);
+        expect(out[0]!.severity).toBe("alert");
+        expect(out[0]!.kind).toBe("weightDown");
+    });
+
+    it("can surface both alerts simultaneously", () => {
+        const out = computePetAlerts({
+            feedings: [{ fedAt: hoursAgo(30) }],
+            weights: [
+                { id: 1, weight: 5.0, weighedAt: daysAgo(8) },
+                { id: 2, weight: 5.6, weighedAt: daysAgo(0) },
+            ],
+            petName: "W",
+            now,
+        });
+        expect(out).toHaveLength(2);
+        expect(out.map((a) => a.kind).sort()).toEqual(["hungry", "weightUp"]);
+    });
+});

--- a/src/lib/pet-alerts.ts
+++ b/src/lib/pet-alerts.ts
@@ -1,0 +1,77 @@
+export type AlertSeverity = "info" | "warn" | "alert";
+export type AlertKind = "hungry" | "weightUp" | "weightDown";
+
+export type PetAlert = {
+    severity: AlertSeverity;
+    kind: AlertKind;
+    text: string;
+};
+
+export type FeedingForAlerts = { fedAt: Date };
+export type WeightForAlerts = {
+    id: number;
+    weight: number;
+    weighedAt: Date;
+};
+
+export const HUNGRY_THRESHOLD_HOURS = 18;
+export const HUNGRY_ALERT_HOURS = 24;
+export const WEIGHT_WARN_PCT = 5;
+export const WEIGHT_ALERT_PCT = 10;
+
+/**
+ * Pure compute used by PetAlerts. Feedings are expected in descending
+ * fedAt order (latest first); weights may be in any order.
+ */
+export function computePetAlerts({
+    feedings,
+    weights,
+    petName,
+    now = Date.now(),
+}: {
+    feedings: ReadonlyArray<FeedingForAlerts>;
+    weights: ReadonlyArray<WeightForAlerts>;
+    petName: string;
+    now?: number;
+}): PetAlert[] {
+    const out: PetAlert[] = [];
+
+    const last = feedings[0];
+    if (last) {
+        const hours = (now - last.fedAt.getTime()) / 3_600_000;
+        if (hours >= HUNGRY_THRESHOLD_HOURS) {
+            out.push({
+                severity: hours >= HUNGRY_ALERT_HOURS ? "alert" : "warn",
+                kind: "hungry",
+                text: `${petName} hasn't been fed in ${Math.floor(hours)}h.`,
+            });
+        }
+    }
+
+    if (weights.length >= 2) {
+        const sorted = [...weights].sort(
+            (a, b) => a.weighedAt.getTime() - b.weighedAt.getTime(),
+        );
+        const latest = sorted[sorted.length - 1]!;
+        const cutoff = now - 7 * 86_400_000;
+        const ref =
+            [...sorted]
+                .reverse()
+                .find((r) => r.weighedAt.getTime() <= cutoff) ?? sorted[0]!;
+        if (ref.id !== latest.id && ref.weight > 0) {
+            const pct = ((latest.weight - ref.weight) / ref.weight) * 100;
+            const abs = Math.abs(pct);
+            if (abs >= WEIGHT_WARN_PCT) {
+                out.push({
+                    severity: abs >= WEIGHT_ALERT_PCT ? "alert" : "warn",
+                    kind: pct > 0 ? "weightUp" : "weightDown",
+                    text: `${petName}'s weight is ${
+                        pct > 0 ? "up" : "down"
+                    } ${abs.toFixed(1)}% over the last week.`,
+                });
+            }
+        }
+    }
+
+    return out;
+}

--- a/src/server/api/petAccess.test.ts
+++ b/src/server/api/petAccess.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { TRPCError } from "@trpc/server";
+
+import { assertPetAccess } from "./petAccess";
+
+function makeMockDb(rows: Array<{ role: "Owner" | "Editor" | "Viewer" }>) {
+    const chain = {
+        select: () => chain,
+        from: () => chain,
+        innerJoin: () => chain,
+        where: () => chain,
+        limit: async () => rows,
+    };
+    return chain as unknown as Parameters<typeof assertPetAccess>[0];
+}
+
+describe("assertPetAccess", () => {
+    it("returns the role when a row exists", async () => {
+        const db = makeMockDb([{ role: "Editor" }]);
+        await expect(assertPetAccess(db, "user_1", 42)).resolves.toBe(
+            "Editor",
+        );
+    });
+
+    it("throws FORBIDDEN when no row matches", async () => {
+        const db = makeMockDb([]);
+        await expect(assertPetAccess(db, "user_1", 42)).rejects.toBeInstanceOf(
+            TRPCError,
+        );
+        try {
+            await assertPetAccess(db, "user_1", 42);
+        } catch (err) {
+            expect(err).toBeInstanceOf(TRPCError);
+            expect((err as TRPCError).code).toBe("FORBIDDEN");
+        }
+    });
+
+    it("returns Owner role correctly", async () => {
+        const db = makeMockDb([{ role: "Owner" }]);
+        await expect(assertPetAccess(db, "u", 1)).resolves.toBe("Owner");
+    });
+
+    it("returns Viewer role correctly", async () => {
+        const db = makeMockDb([{ role: "Viewer" }]);
+        await expect(assertPetAccess(db, "u", 1)).resolves.toBe("Viewer");
+    });
+});

--- a/src/trpc/react.tsx
+++ b/src/trpc/react.tsx
@@ -1,24 +1,40 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+    QueryCache,
+    QueryClient,
+    QueryClientProvider,
+} from "@tanstack/react-query";
 import { loggerLink, unstable_httpBatchStreamLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
 import SuperJSON from "superjson";
+import { toast } from "sonner";
 
 import { type AppRouter } from "~/server/api/root";
 
-const createQueryClient = () => new QueryClient();
+const createQueryClient = () =>
+    new QueryClient({
+        queryCache: new QueryCache({
+            onError: (err, query) => {
+                // Skip the toast if the query opted out via meta.silentError.
+                if ((query.meta as { silentError?: boolean })?.silentError) return;
+                const message =
+                    err instanceof Error ? err.message : "Couldn't load data";
+                toast.error(message);
+            },
+        }),
+    });
 
 let clientQueryClientSingleton: QueryClient | undefined = undefined;
 const getQueryClient = () => {
-  if (typeof window === "undefined") {
-    // Server: always make a new query client
-    return createQueryClient();
-  }
-  // Browser: use singleton pattern to keep the same query client
-  return (clientQueryClientSingleton ??= createQueryClient());
+    if (typeof window === "undefined") {
+        // Server: always make a new query client
+        return createQueryClient();
+    }
+    // Browser: use singleton pattern to keep the same query client
+    return (clientQueryClientSingleton ??= createQueryClient());
 };
 
 export const api = createTRPCReact<AppRouter>();
@@ -38,40 +54,40 @@ export type RouterInputs = inferRouterInputs<AppRouter>;
 export type RouterOutputs = inferRouterOutputs<AppRouter>;
 
 export function TRPCReactProvider(props: { children: React.ReactNode }) {
-  const queryClient = getQueryClient();
+    const queryClient = getQueryClient();
 
-  const [trpcClient] = useState(() =>
-    api.createClient({
-      links: [
-        loggerLink({
-          enabled: (op) =>
-            process.env.NODE_ENV === "development" ||
-            (op.direction === "down" && op.result instanceof Error),
-        }),
-        unstable_httpBatchStreamLink({
-          transformer: SuperJSON,
-          url: getBaseUrl() + "/api/trpc",
-          headers: () => {
-            const headers = new Headers();
-            headers.set("x-trpc-source", "nextjs-react");
-            return headers;
-          },
-        }),
-      ],
-    })
-  );
+    const [trpcClient] = useState(() =>
+        api.createClient({
+            links: [
+                loggerLink({
+                    enabled: (op) =>
+                        process.env.NODE_ENV === "development" ||
+                        (op.direction === "down" && op.result instanceof Error),
+                }),
+                unstable_httpBatchStreamLink({
+                    transformer: SuperJSON,
+                    url: getBaseUrl() + "/api/trpc",
+                    headers: () => {
+                        const headers = new Headers();
+                        headers.set("x-trpc-source", "nextjs-react");
+                        return headers;
+                    },
+                }),
+            ],
+        })
+    );
 
-  return (
-    <QueryClientProvider client={queryClient}>
-      <api.Provider client={trpcClient} queryClient={queryClient}>
-        {props.children}
-      </api.Provider>
-    </QueryClientProvider>
-  );
+    return (
+        <QueryClientProvider client={queryClient}>
+            <api.Provider client={trpcClient} queryClient={queryClient}>
+                {props.children}
+            </api.Provider>
+        </QueryClientProvider>
+    );
 }
 
 function getBaseUrl() {
-  if (typeof window !== "undefined") return window.location.origin;
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-  return `http://localhost:${process.env.PORT ?? 3000}`;
+    if (typeof window !== "undefined") return window.location.origin;
+    if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+    return `http://localhost:${process.env.PORT ?? 3000}`;
 }


### PR DESCRIPTION
## Summary
S29. PWA-installable: manifest, icons, theme color.

### Added
- `public/site.webmanifest` — name, short_name, `start_url: /dashboard`, `display: standalone`, theme color, icons array
- `public/icon.svg` (512), `public/apple-touch-icon.svg` (180) — inline SVG with paw emoji. Lightweight; real raster icons can replace later
- `layout.tsx` metadata: manifest link, multiple icon refs, `appleWebApp`, dark-mode-aware `themeColor` via Next 14 `viewport` export

### Test plan
- [x] `pnpm typecheck` / `pnpm lint` clean
- [ ] Chrome on Android: "Install app" prompt appears
- [ ] Safari iOS: Share → "Add to Home Screen" uses our icon and label
- [ ] Installed PWA launches into `/dashboard` in standalone mode

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_