### PR TITLE
S31: error.tsx + global tRPC query error toasts

### DIFF
--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+
+export default function DashboardError({
+    error,
+    reset,
+}: {
+    error: Error & { digest?: string };
+    reset: () => void;
+}) {
+    useEffect(() => {
+        console.error(error);
+    }, [error]);
+
+    return (
+        <div className="mx-auto max-w-md py-8">
+            <Card className="border-destructive/40">
+                <CardHeader>
+                    <CardTitle className="text-destructive">
+                        Couldn&apos;t load this page
+                    </CardTitle>
+                    <CardDescription>
+                        {error.message || "Unknown error."}
+                        {error.digest && (
+                            <span className="ml-2 text-xs">ref {error.digest}</span>
+                        )}
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="flex gap-2">
+                    <Button type="button" onClick={reset}>
+                        Try again
+                    </Button>
+                    <Button asChild variant="outline">
+                        <a href="/dashboard">Back to dashboard</a>
+                    </Button>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { Button } from "~/components/ui/button";
+
+export default function GlobalError({
+    error,
+    reset,
+}: {
+    error: Error & { digest?: string };
+    reset: () => void;
+}) {
+    useEffect(() => {
+        console.error(error);
+    }, [error]);
+
+    return (
+        <div className="container mx-auto flex min-h-screen max-w-md flex-col items-center justify-center gap-4 text-center">
+            <h1 className="text-2xl font-bold">Something went wrong</h1>
+            <p className="text-sm text-muted-foreground">
+                {error.message || "Unknown error."}
+                {error.digest && (
+                    <span className="block text-xs">ref {error.digest}</span>
+                )}
+            </p>
+            <div className="flex gap-2">
+                <Button type="button" onClick={reset}>
+                    Try again
+                </Button>
+                <Button asChild variant="outline">
+                    <a href="/dashboard">Back to dashboard</a>
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/trpc/react.tsx
+++ b/src/trpc/react.tsx
@@ -1,24 +1,40 @@
 "use client";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+    QueryCache,
+    QueryClient,
+    QueryClientProvider,
+} from "@tanstack/react-query";
 import { loggerLink, unstable_httpBatchStreamLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
 import SuperJSON from "superjson";
+import { toast } from "sonner";
 
 import { type AppRouter } from "~/server/api/root";
 
-const createQueryClient = () => new QueryClient();
+const createQueryClient = () =>
+    new QueryClient({
+        queryCache: new QueryCache({
+            onError: (err, query) => {
+                // Skip the toast if the query opted out via meta.silentError.
+                if ((query.meta as { silentError?: boolean })?.silentError) return;
+                const message =
+                    err instanceof Error ? err.message : "Couldn't load data";
+                toast.error(message);
+            },
+        }),
+    });
 
 let clientQueryClientSingleton: QueryClient | undefined = undefined;
 const getQueryClient = () => {
-  if (typeof window === "undefined") {
-    // Server: always make a new query client
-    return createQueryClient();
-  }
-  // Browser: use singleton pattern to keep the same query client
-  return (clientQueryClientSingleton ??= createQueryClient());
+    if (typeof window === "undefined") {
+        // Server: always make a new query client
+        return createQueryClient();
+    }
+    // Browser: use singleton pattern to keep the same query client
+    return (clientQueryClientSingleton ??= createQueryClient());
 };
 
 export const api = createTRPCReact<AppRouter>();
@@ -38,40 +54,40 @@ export type RouterInputs = inferRouterInputs<AppRouter>;
 export type RouterOutputs = inferRouterOutputs<AppRouter>;
 
 export function TRPCReactProvider(props: { children: React.ReactNode }) {
-  const queryClient = getQueryClient();
+    const queryClient = getQueryClient();
 
-  const [trpcClient] = useState(() =>
-    api.createClient({
-      links: [
-        loggerLink({
-          enabled: (op) =>
-            process.env.NODE_ENV === "development" ||
-            (op.direction === "down" && op.result instanceof Error),
-        }),
-        unstable_httpBatchStreamLink({
-          transformer: SuperJSON,
-          url: getBaseUrl() + "/api/trpc",
-          headers: () => {
-            const headers = new Headers();
-            headers.set("x-trpc-source", "nextjs-react");
-            return headers;
-          },
-        }),
-      ],
-    })
-  );
+    const [trpcClient] = useState(() =>
+        api.createClient({
+            links: [
+                loggerLink({
+                    enabled: (op) =>
+                        process.env.NODE_ENV === "development" ||
+                        (op.direction === "down" && op.result instanceof Error),
+                }),
+                unstable_httpBatchStreamLink({
+                    transformer: SuperJSON,
+                    url: getBaseUrl() + "/api/trpc",
+                    headers: () => {
+                        const headers = new Headers();
+                        headers.set("x-trpc-source", "nextjs-react");
+                        return headers;
+                    },
+                }),
+            ],
+        })
+    );
 
-  return (
-    <QueryClientProvider client={queryClient}>
-      <api.Provider client={trpcClient} queryClient={queryClient}>
-        {props.children}
-      </api.Provider>
-    </QueryClientProvider>
-  );
+    return (
+        <QueryClientProvider client={queryClient}>
+            <api.Provider client={trpcClient} queryClient={queryClient}>
+                {props.children}
+            </api.Provider>
+        </QueryClientProvider>
+    );
 }
 
 function getBaseUrl() {
-  if (typeof window !== "undefined") return window.location.origin;
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-  return `http://localhost:${process.env.PORT ?? 3000}`;
+    if (typeof window !== "undefined") return window.location.origin;
+    if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+    return `http://localhost:${process.env.PORT ?? 3000}`;
 }


### PR DESCRIPTION
## Summary
S31 (final of Batch 3). Crash + query-error UX.

### Changes
- `src/app/error.tsx` — full-page fallback when an uncaught error bubbles out of any client component. Logs to console, surfaces message + digest, "Try again" / "Back to dashboard".
- `src/app/dashboard/error.tsx` — scoped fallback rendered inside the existing dashboard chrome.
- `~/trpc/react.tsx` — `QueryClient` now has a `QueryCache.onError` that fires a sonner toast for any unhandled query error. Queries that want silence can set `meta: { silentError: true }`. Mutation errors are already toasted at the call site (S22).

### Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` clean
- [ ] Throw inside a server component → see the page fallback
- [ ] Force a `getPets` failure → red toast appears with the message

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_