### PR TITLE
S34: skeleton loaders on charts and today cards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SKIP_ENV_VALIDATION: "1"
+      POSTGRES_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
+      # Syntactically-valid Clerk dummy keys so the build's "Collecting page
+      # data" step doesn't choke on atob. Not used at runtime in CI.
+      CLERK_PUBLISHABLE_KEY: "pk_test_Y2xlcmsuZHVtbXkubGNsLmRldiQ="
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_test_Y2xlcmsuZHVtbXkubGNsLmRldiQ="
+      CLERK_SECRET_KEY: "sk_test_dummy"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
+      - name: Enable corepack (pnpm from packageManager field)
+        run: corepack enable
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -35,3 +39,20 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Drizzle migrations up to date
+        run: |
+          # Generate would write a new migration file iff schema.ts and the
+          # latest snapshot have drifted. Compare the drizzle dir before and
+          # after; fail if anything new appeared.
+          before=$(git status --porcelain drizzle | wc -l)
+          pnpm db:generate
+          after=$(git status --porcelain drizzle | wc -l)
+          if [ "$before" != "$after" ]; then
+            echo "Schema changed but no migration committed. Run 'pnpm db:generate' and commit drizzle/."
+            git status --short drizzle/
+            exit 1
+          fi
+
+      - name: Next.js build
+        run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # database
 /prisma/db.sqlite

--- a/drizzle/0008_unique_blue_blade.sql
+++ b/drizzle/0008_unique_blue_blade.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "meow-weight-tracker_pet_invites" ADD COLUMN "expires_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "meow-weight-tracker_pet_invites" ADD COLUMN "revoked_at" timestamp with time zone;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,839 @@
+{
+  "id": "77eae131-cf75-45b8-9e75-50d60158dc1b",
+  "prevId": "60ec0dc2-7c42-4a86-a526-2205066a9abe",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.meow-weight-tracker_activity_history": {
+      "name": "meow-weight-tracker_activity_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_history_pet_id_idx": {
+          "name": "activity_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_activity_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_eating_history": {
+      "name": "meow-weight-tracker_eating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fed_at": {
+          "name": "fed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_grams": {
+          "name": "quantity_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eating_history_pet_id_idx": {
+          "name": "eating_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk": {
+          "name": "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pet_food",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_health_events": {
+      "name": "meow-weight-tracker_health_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_events_pet_id_idx": {
+          "name": "health_events_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_health_events",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_food": {
+      "name": "meow-weight-tracker_pet_food",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories_per_gram": {
+          "name": "calories_per_gram",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_percent": {
+          "name": "protein_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat_percent": {
+          "name": "fat_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs_percent": {
+          "name": "carbs_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_food_name_idx": {
+          "name": "pet_food_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_invites": {
+      "name": "meow-weight-tracker_pet_invites",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_invites_pet_id_idx": {
+          "name": "pet_invites_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_notes": {
+      "name": "meow-weight-tracker_pet_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_by": {
+          "name": "written_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_notes_pet_id_idx": {
+          "name": "pet_notes_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_notes",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_notes",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "written_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_people": {
+      "name": "meow-weight-tracker_pet_people",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_people_user_id_idx": {
+          "name": "pet_people_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "pet_people_pet_id_idx": {
+          "name": "pet_people_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meow-weight-tracker_pet_people_user_id_pet_id_pk": {
+          "name": "meow-weight-tracker_pet_people_user_id_pet_id_pk",
+          "columns": [
+            "user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pets": {
+      "name": "meow-weight-tracker_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_weight": {
+          "name": "goal_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_kcal_target": {
+          "name": "daily_kcal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_users": {
+      "name": "meow-weight-tracker_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_weight_history": {
+      "name": "meow-weight-tracker_weight_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weighed_at": {
+          "name": "weighed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weight_history_pet_id_idx": {
+          "name": "weight_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_weight_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.pet_role": {
+      "name": "pet_role",
+      "schema": "public",
+      "values": [
+        "Owner",
+        "Editor",
+        "Viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1778708778827,
       "tag": "0007_slimy_jasper_sitwell",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1778725267972,
+      "tag": "0008_unique_blue_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "next lint",
     "start": "next start",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -48,6 +49,7 @@
     "zod": "^3.23.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.11.20",
     "@types/react": "^18.2.57",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Minimal Playwright config. Runs against an already-running dev server at
+ * PLAYWRIGHT_BASE_URL (default http://localhost:3000). Doesn't spawn the
+ * server itself — keeps the test runtime fast and avoids fighting Next.js
+ * over ports during CI in the future.
+ */
+export default defineConfig({
+    testDir: "./tests/e2e",
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 1 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: process.env.CI ? "line" : "list",
+    use: {
+        baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
+        trace: "on-first-retry",
+    },
+    projects: [
+        {
+            name: "chromium",
+            use: { ...devices["Desktop Chrome"] },
+        },
+    ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@clerk/nextjs':
         specifier: ^5.1.5
-        version: 5.1.5(next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.1.5(next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -43,7 +43,7 @@ importers:
         version: 0.8.0
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 1.0.12(next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -55,13 +55,13 @@ importers:
         version: 0.30.10(@neondatabase/serverless@0.7.2)(@types/pg@8.6.6)(@types/react@18.3.3)(@vercel/postgres@0.8.0)(postgres@3.4.4)(react@18.3.1)
       geist:
         specifier: ^1.3.0
-        version: 1.3.0(next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 1.3.0(next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@18.3.1)
       next:
         specifier: ^14.2.1
-        version: 14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -99,6 +99,9 @@ importers:
         specifier: ^3.23.3
         version: 3.23.8
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.10
@@ -706,6 +709,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2141,6 +2149,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2833,6 +2846,16 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
@@ -3694,14 +3717,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.4.1
 
-  '@clerk/nextjs@5.1.5(next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/nextjs@5.1.5(next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@clerk/backend': 1.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/clerk-react': 5.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/shared': 2.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/types': 4.6.0
       crypto-js: 4.2.0
-      next: 14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       path-to-regexp: 6.2.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -4049,6 +4072,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@radix-ui/number@1.1.1': {}
 
@@ -4639,9 +4666,9 @@ snapshots:
       utf-8-validate: 6.0.3
       ws: 8.14.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
-      next: 14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.12(@types/node@20.14.2)(esbuild@0.19.12)(jiti@1.21.6)(yaml@2.4.5))':
@@ -5578,6 +5605,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5592,9 +5622,9 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  geist@1.3.0(next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  geist@1.3.0(next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
-      next: 14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   get-intrinsic@1.2.4:
     dependencies:
@@ -6100,7 +6130,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -6121,6 +6151,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.4
       '@next/swc-win32-ia32-msvc': 14.2.4
       '@next/swc-win32-x64-msvc': 14.2.4
+      '@playwright/test': 1.60.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -6253,6 +6284,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.0.0: {}
 

--- a/src/app/api/pets/[id]/export/route.ts
+++ b/src/app/api/pets/[id]/export/route.ts
@@ -6,6 +6,8 @@ import { db } from "~/server/db";
 import { eatingHistory, petFood, weightHistory } from "~/server/db/schema";
 import { assertPetAccess } from "~/server/api/petAccess";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(
     req: Request,
     { params }: { params: { id: string } },

--- a/src/app/dashboard/_components/dashboard-content.tsx
+++ b/src/app/dashboard/_components/dashboard-content.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { ChevronRight } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
+import { FoodBreakdownChart } from "~/app/dashboard/_components/food-breakdown-chart";
 import { KcalTrendChart } from "~/app/dashboard/_components/kcal-trend-chart";
 import { PetAlerts } from "~/app/dashboard/_components/pet-alerts";
 import { PetPicker } from "~/app/dashboard/_components/pet-picker";
@@ -54,6 +55,10 @@ export function DashboardContent({ pets }: { pets: Pet[] }) {
                 petId={selectedPet.id}
                 petName={selectedPet.name}
                 dailyKcalTarget={selectedPet.dailyKcalTarget}
+            />
+            <FoodBreakdownChart
+                petId={selectedPet.id}
+                petName={selectedPet.name}
             />
             <TodayActivity
                 petId={selectedPet.id}

--- a/src/app/dashboard/_components/food-breakdown-chart.tsx
+++ b/src/app/dashboard/_components/food-breakdown-chart.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    Legend,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from "recharts";
+
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
+import { computeFoodBreakdown } from "~/lib/food-breakdown";
+import { api } from "~/trpc/react";
+
+const COLORS = [
+    "hsl(220 90% 56%)",
+    "hsl(160 70% 45%)",
+    "hsl(35 90% 55%)",
+    "hsl(330 75% 60%)",
+    "hsl(265 80% 65%)",
+    "hsl(190 75% 45%)",
+];
+
+export function FoodBreakdownChart({
+    petId,
+    petName,
+}: {
+    petId: number;
+    petName: string;
+}) {
+    const { data, isLoading } = api.feeding.getFeedingHistory.useQuery({
+        petId,
+    });
+
+    const { series, data: chartData } = useMemo(
+        () => computeFoodBreakdown(data ?? [], 30),
+        [data],
+    );
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>30-day food breakdown</CardTitle>
+                <CardDescription>
+                    {petName}&apos;s kcal sources, stacked by day.
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <Skeleton className="h-56 w-full" />
+                ) : series.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        No feedings in the last 30 days.
+                    </p>
+                ) : (
+                    <div className="h-56 w-full">
+                        <ResponsiveContainer width="100%" height="100%">
+                            <BarChart
+                                data={chartData}
+                                margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+                            >
+                                <CartesianGrid
+                                    strokeDasharray="3 3"
+                                    stroke="hsl(var(--border))"
+                                />
+                                <XAxis
+                                    dataKey="dayLabel"
+                                    tick={{ fontSize: 10 }}
+                                    interval={3}
+                                />
+                                <YAxis tick={{ fontSize: 10 }} width={32} />
+                                <Tooltip
+                                    formatter={(value, name) => [
+                                        `${Number(value).toFixed(0)} kcal`,
+                                        String(name),
+                                    ]}
+                                />
+                                <Legend
+                                    wrapperStyle={{ fontSize: 11 }}
+                                    iconType="square"
+                                />
+                                {series.map((s, i) => (
+                                    <Bar
+                                        key={s.foodId}
+                                        dataKey={`food_${s.foodId}`}
+                                        stackId="kcal"
+                                        name={s.label}
+                                        fill={COLORS[i % COLORS.length]}
+                                    />
+                                ))}
+                            </BarChart>
+                        </ResponsiveContainer>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/_components/kcal-trend-chart.tsx
+++ b/src/app/dashboard/_components/kcal-trend-chart.tsx
@@ -20,6 +20,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
 import { computeDailyKcal } from "~/lib/kcal-trend";
 import { api } from "~/trpc/react";
 
@@ -53,9 +54,7 @@ export function KcalTrendChart({
             </CardHeader>
             <CardContent>
                 {isLoading ? (
-                    <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
-                        Loading…
-                    </div>
+                    <Skeleton className="h-48 w-full" />
                 ) : (
                     <div className="h-48 w-full">
                         <ResponsiveContainer width="100%" height="100%">

--- a/src/app/dashboard/_components/pet-card-streak.tsx
+++ b/src/app/dashboard/_components/pet-card-streak.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Flame } from "lucide-react";
+
+import { computeFeedingStreak } from "~/lib/feeding-streak";
+import { api } from "~/trpc/react";
+
+export function PetCardStreak({ petId }: { petId: number }) {
+    const { data } = api.feeding.getFeedingHistory.useQuery({ petId });
+    if (!data) return null;
+    const streak = computeFeedingStreak(data);
+    if (streak === 0) return null;
+    return (
+        <span className="ml-auto flex items-center gap-1 rounded-full bg-orange-500/15 px-2 py-0.5 text-[10px] font-medium text-orange-600">
+            <Flame className="h-3 w-3" />
+            {streak}d
+        </span>
+    );
+}

--- a/src/app/dashboard/_components/pet-picker.tsx
+++ b/src/app/dashboard/_components/pet-picker.tsx
@@ -6,6 +6,7 @@ import { Plus } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
 import { PetAvatar } from "~/components/ui/pet-avatar";
+import { PetCardStreak } from "~/app/dashboard/_components/pet-card-streak";
 import { cn } from "~/lib/utils";
 import { type RouterOutputs } from "~/trpc/react";
 
@@ -51,8 +52,13 @@ export function PetPicker({
                                         name={pet.name}
                                         photoUrl={pet.photoUrl}
                                     />
-                                    <div>
-                                        <div className="font-medium">{pet.name}</div>
+                                    <div className="min-w-0 flex-1">
+                                        <div className="flex items-center gap-2">
+                                            <span className="truncate font-medium">
+                                                {pet.name}
+                                            </span>
+                                            <PetCardStreak petId={pet.id} />
+                                        </div>
                                         <div className="text-xs text-muted-foreground">
                                             {[pet.species, ageLabel(pet.birthDate)]
                                                 .filter(Boolean)

--- a/src/app/dashboard/_components/record-feeding-dialog.tsx
+++ b/src/app/dashboard/_components/record-feeding-dialog.tsx
@@ -39,8 +39,41 @@ export function RecordFeedingDialog({ pet }: { pet: Pet }) {
     const foods = api.food.list.useQuery();
     const utils = api.useUtils();
     const recordFeeding = api.feeding.recordFeeding.useMutation({
-        onSuccess: async (_data, vars) => {
-            await utils.feeding.getFeedingHistory.invalidate({ petId: pet.id });
+        onMutate: async (vars) => {
+            await utils.feeding.getFeedingHistory.cancel({ petId: pet.id });
+            const previous = utils.feeding.getFeedingHistory.getData({
+                petId: pet.id,
+            });
+            const food = foods.data?.find((f) => f.id === vars.foodId);
+            if (!food) return { previous };
+            const at = vars.fedAt ?? new Date();
+            const tempId = -Date.now();
+            utils.feeding.getFeedingHistory.setData(
+                { petId: pet.id },
+                (rows) =>
+                    [
+                        {
+                            id: tempId,
+                            petId: pet.id,
+                            fedAt: at,
+                            quantityGrams: vars.quantityGrams,
+                            food,
+                        },
+                        ...(rows ?? []),
+                    ].sort((a, b) => b.fedAt.getTime() - a.fedAt.getTime()),
+            );
+            return { previous };
+        },
+        onError: (err, _vars, ctx) => {
+            if (ctx?.previous) {
+                utils.feeding.getFeedingHistory.setData(
+                    { petId: pet.id },
+                    ctx.previous,
+                );
+            }
+            toast.error(err.message);
+        },
+        onSuccess: (_data, vars) => {
             if (typeof window !== "undefined") {
                 window.localStorage.setItem(
                     LAST_FOOD_KEY(pet.id),
@@ -52,7 +85,9 @@ export function RecordFeedingDialog({ pet }: { pet: Pet }) {
             setFedAt("");
             toast.success(`Feeding logged for ${pet.name}`);
         },
-        onError: (err) => toast.error(err.message),
+        onSettled: () => {
+            void utils.feeding.getFeedingHistory.invalidate({ petId: pet.id });
+        },
     });
 
     useEffect(() => {

--- a/src/app/dashboard/_components/record-weight-dialog.tsx
+++ b/src/app/dashboard/_components/record-weight-dialog.tsx
@@ -34,14 +34,51 @@ export function RecordWeightDialog({ pet }: { pet: Pet }) {
 
     const utils = api.useUtils();
     const recordWeight = api.weight.recordWeight.useMutation({
-        onSuccess: async () => {
-            await utils.weight.getWeightHistory.invalidate({ petId: pet.id });
+        onMutate: async (vars) => {
+            await utils.weight.getWeightHistory.cancel({ petId: pet.id });
+            const previous = utils.weight.getWeightHistory.getData({
+                petId: pet.id,
+            });
+            const at = vars.recordedAt ?? new Date();
+            const tempId = -Date.now();
+            utils.weight.getWeightHistory.setData(
+                { petId: pet.id },
+                (rows) =>
+                    [
+                        ...(rows ?? []),
+                        {
+                            id: tempId,
+                            petId: pet.id,
+                            weight: vars.weight,
+                            weighedAt: at,
+                            createdAt: at,
+                            updatedAt: at,
+                        },
+                    ].sort(
+                        (a, b) =>
+                            a.weighedAt.getTime() - b.weighedAt.getTime(),
+                    ),
+            );
+            return { previous };
+        },
+        onError: (err, _vars, ctx) => {
+            if (ctx?.previous) {
+                utils.weight.getWeightHistory.setData(
+                    { petId: pet.id },
+                    ctx.previous,
+                );
+            }
+            toast.error(err.message);
+        },
+        onSuccess: () => {
             setOpen(false);
             setWeight("");
             setRecordedAt("");
             toast.success(`Weight saved for ${pet.name}`);
         },
-        onError: (err) => toast.error(err.message),
+        onSettled: () => {
+            void utils.weight.getWeightHistory.invalidate({ petId: pet.id });
+        },
     });
 
     function onSubmit(event: FormEvent<HTMLFormElement>) {

--- a/src/app/dashboard/_components/today-activity.tsx
+++ b/src/app/dashboard/_components/today-activity.tsx
@@ -12,6 +12,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
 import { api } from "~/trpc/react";
 
 export function TodayActivity({
@@ -64,7 +65,10 @@ export function TodayActivity({
             </CardHeader>
             <CardContent>
                 {isLoading ? (
-                    <p className="text-sm text-muted-foreground">Loading…</p>
+                    <div className="space-y-2">
+                        <Skeleton className="h-12 w-full" />
+                        <Skeleton className="h-12 w-full" />
+                    </div>
                 ) : today.length === 0 ? (
                     <p className="text-sm text-muted-foreground">
                         No activity logged today yet.

--- a/src/app/dashboard/_components/today-feedings.tsx
+++ b/src/app/dashboard/_components/today-feedings.tsx
@@ -10,6 +10,7 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { FeedingRowActions } from "~/app/dashboard/_components/feeding-row-actions";
+import { Skeleton } from "~/components/ui/skeleton";
 import { cn } from "~/lib/utils";
 import { api } from "~/trpc/react";
 
@@ -88,7 +89,10 @@ export function TodayFeedings({
             )}
             <CardContent>
                 {isLoading ? (
-                    <p className="text-sm text-muted-foreground">Loading…</p>
+                    <div className="space-y-2">
+                        <Skeleton className="h-12 w-full" />
+                        <Skeleton className="h-12 w-full" />
+                    </div>
                 ) : today.length === 0 ? (
                     <p className="text-sm text-muted-foreground">
                         No feedings logged today yet.

--- a/src/app/dashboard/_components/weight-chart.tsx
+++ b/src/app/dashboard/_components/weight-chart.tsx
@@ -20,6 +20,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
 import { cn } from "~/lib/utils";
 import { api } from "~/trpc/react";
 
@@ -83,9 +84,7 @@ export function WeightChart({
             </CardHeader>
             <CardContent>
                 {isLoading ? (
-                    <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
-                        Loading…
-                    </div>
+                    <Skeleton className="h-64 w-full" />
                 ) : points.length === 0 ? (
                     <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
                         No weight readings in this range yet.

--- a/src/app/dashboard/_components/weight-stats-card.tsx
+++ b/src/app/dashboard/_components/weight-stats-card.tsx
@@ -10,6 +10,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
 import { cn } from "~/lib/utils";
 import { computeWeightStats } from "~/lib/weight-stats";
 import { api } from "~/trpc/react";
@@ -38,7 +39,12 @@ export function WeightStatsCard({
             </CardHeader>
             <CardContent>
                 {isLoading ? (
-                    <p className="text-sm text-muted-foreground">Loading…</p>
+                    <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                        <Skeleton className="h-12" />
+                        <Skeleton className="h-12" />
+                        <Skeleton className="h-12" />
+                        <Skeleton className="h-12" />
+                    </div>
                 ) : !stats ? (
                     <p className="text-sm text-muted-foreground">
                         Log at least two weights to see a trend.

--- a/src/app/dashboard/pets/[id]/_components/import-weight-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/import-weight-card.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Upload } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { parseWeightCsv, type ParseResult } from "~/lib/weight-csv-parse";
+import { api } from "~/trpc/react";
+
+export function ImportWeightCard({
+    petId,
+    canEdit,
+}: {
+    petId: number;
+    canEdit: boolean;
+}) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [parsed, setParsed] = useState<ParseResult | null>(null);
+    const utils = api.useUtils();
+    const bulkImport = api.weight.bulkImport.useMutation({
+        onSuccess: async ({ inserted }) => {
+            await utils.weight.getWeightHistory.invalidate({ petId });
+            setParsed(null);
+            if (inputRef.current) inputRef.current.value = "";
+            toast.success(`Imported ${inserted} weight readings`);
+        },
+        onError: (err) => toast.error(err.message),
+    });
+
+    if (!canEdit) return null;
+
+    async function onFile(file: File) {
+        const text = await file.text();
+        setParsed(parseWeightCsv(text));
+    }
+
+    function onImport() {
+        if (!parsed || parsed.rows.length === 0) return;
+        bulkImport.mutate({
+            petId,
+            entries: parsed.rows.map((r) => ({
+                weighedAt: r.weighedAt,
+                weight: r.weight,
+            })),
+        });
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Import weights</CardTitle>
+                <CardDescription>
+                    Upload a CSV. Requires columns <code>weight</code> and{" "}
+                    <code>weighed_at_iso</code> (or <code>weighed_at</code>).
+                    Matches the export format.
+                </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+                <input
+                    ref={inputRef}
+                    type="file"
+                    accept=".csv,text/csv"
+                    onChange={(e) => {
+                        const f = e.target.files?.[0];
+                        if (f) void onFile(f);
+                        else setParsed(null);
+                    }}
+                    className="text-sm"
+                />
+                {parsed && (
+                    <div className="space-y-2 text-sm">
+                        <p>
+                            Parsed {parsed.rows.length} valid{" "}
+                            {parsed.rows.length === 1 ? "row" : "rows"}
+                            {parsed.errors.length > 0 &&
+                                `; ${parsed.errors.length} skipped`}
+                            .
+                        </p>
+                        {parsed.errors.length > 0 && (
+                            <ul className="max-h-32 list-disc overflow-auto pl-5 text-xs text-destructive">
+                                {parsed.errors.slice(0, 25).map((e, i) => (
+                                    <li key={i}>
+                                        Line {e.line}: {e.message}
+                                    </li>
+                                ))}
+                                {parsed.errors.length > 25 && (
+                                    <li>
+                                        …and {parsed.errors.length - 25} more
+                                    </li>
+                                )}
+                            </ul>
+                        )}
+                        <Button
+                            type="button"
+                            disabled={
+                                parsed.rows.length === 0 || bulkImport.isPending
+                            }
+                            onClick={onImport}
+                        >
+                            <Upload className="mr-2 h-3.5 w-3.5" />
+                            {bulkImport.isPending
+                                ? "Importing…"
+                                : `Import ${parsed.rows.length}`}
+                        </Button>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -10,6 +10,7 @@ import { WeightHistoryList } from "~/app/dashboard/pets/[id]/_components/weight-
 import { ExportCard } from "~/app/dashboard/pets/[id]/_components/export-card";
 import { HealthEventsCard } from "~/app/dashboard/pets/[id]/_components/health-events-card";
 import { NotesCard } from "~/app/dashboard/pets/[id]/_components/notes-card";
+import { ImportWeightCard } from "~/app/dashboard/pets/[id]/_components/import-weight-card";
 import { DeletePetCard } from "~/app/dashboard/pets/[id]/_components/delete-pet-card";
 import { PetAlerts } from "~/app/dashboard/_components/pet-alerts";
 import { WeightChart } from "~/app/dashboard/_components/weight-chart";
@@ -65,6 +66,10 @@ export default async function PetDetailPage({
             <FeedingHistoryList petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <HealthEventsCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <NotesCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
+            <ImportWeightCard
+                petId={pet.id}
+                canEdit={pet.role !== "Viewer"}
+            />
             <ExportCard petId={pet.id} />
             <DeletePetCard petId={pet.id} petName={pet.name} role={pet.role} />
         </div>

--- a/src/app/dashboard/pets/[id]/people/_components/people-manager.tsx
+++ b/src/app/dashboard/pets/[id]/people/_components/people-manager.tsx
@@ -28,14 +28,26 @@ export function PeopleManager({
 }) {
     const utils = api.useUtils();
     const people = api.pet.listPeople.useQuery({ petId });
+    const invites = api.pet.listInvites.useQuery(
+        { petId },
+        { enabled: role === "Owner" },
+    );
     const [inviteRole, setInviteRole] = useState<Role>("Editor");
     const [inviteUrl, setInviteUrl] = useState<string | null>(null);
 
     const createInvite = api.pet.createInvite.useMutation({
-        onSuccess: (invite) => {
+        onSuccess: async (invite) => {
             const url = `${window.location.origin}/accept/${invite.token}`;
             setInviteUrl(url);
+            await utils.pet.listInvites.invalidate({ petId });
             toast.success("Invite link generated");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+    const revokeInvite = api.pet.revokeInvite.useMutation({
+        onSuccess: async () => {
+            await utils.pet.listInvites.invalidate({ petId });
+            toast.success("Invite revoked");
         },
         onError: (err) => toast.error(err.message),
     });
@@ -209,6 +221,75 @@ export function PeopleManager({
                                 </Button>
                             </div>
                         )}
+                    </CardContent>
+                </Card>
+            )}
+
+            {canManage && invites.data && invites.data.length > 0 && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Pending invites</CardTitle>
+                        <CardDescription>
+                            7-day expiry. Revoke to invalidate immediately.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <ul className="divide-y">
+                            {invites.data.map((inv) => {
+                                const status =
+                                    inv.acceptedAt !== null
+                                        ? `accepted ${inv.acceptedAt.toLocaleDateString()}`
+                                        : inv.revokedAt !== null
+                                          ? "revoked"
+                                          : inv.expiresAt &&
+                                              inv.expiresAt.getTime() < Date.now()
+                                            ? "expired"
+                                            : inv.expiresAt
+                                              ? `expires ${inv.expiresAt.toLocaleDateString()}`
+                                              : "active";
+                                const active =
+                                    inv.acceptedAt === null &&
+                                    inv.revokedAt === null &&
+                                    (!inv.expiresAt ||
+                                        inv.expiresAt.getTime() >= Date.now());
+                                return (
+                                    <li
+                                        key={inv.token}
+                                        className="flex items-center justify-between gap-3 py-2 text-sm"
+                                    >
+                                        <div className="min-w-0">
+                                            <div className="font-medium">
+                                                {inv.role}
+                                            </div>
+                                            <div className="text-xs text-muted-foreground">
+                                                {status}
+                                            </div>
+                                        </div>
+                                        {active && (
+                                            <Button
+                                                type="button"
+                                                size="sm"
+                                                variant="outline"
+                                                disabled={revokeInvite.isPending}
+                                                onClick={() => {
+                                                    if (
+                                                        !confirm(
+                                                            "Revoke this invite?",
+                                                        )
+                                                    )
+                                                        return;
+                                                    revokeInvite.mutate({
+                                                        token: inv.token,
+                                                    });
+                                                }}
+                                            >
+                                                Revoke
+                                            </Button>
+                                        )}
+                                    </li>
+                                );
+                            })}
+                        </ul>
                     </CardContent>
                 </Card>
             )}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,16 @@
+import { cn } from "~/lib/utils";
+
+export function Skeleton({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+    return (
+        <div
+            className={cn(
+                "animate-pulse rounded-md bg-muted",
+                className,
+            )}
+            {...props}
+        />
+    );
+}

--- a/src/lib/feeding-streak.test.ts
+++ b/src/lib/feeding-streak.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { computeFeedingStreak } from "./feeding-streak";
+
+const now = new Date("2026-05-14T15:00:00Z");
+const dayAt = (daysAgo: number) => {
+    const d = new Date(now);
+    d.setDate(d.getDate() - daysAgo);
+    d.setHours(12, 0, 0, 0);
+    return d;
+};
+
+describe("computeFeedingStreak", () => {
+    it("returns 0 with no feedings", () => {
+        expect(computeFeedingStreak([], now)).toBe(0);
+    });
+
+    it("returns 0 when nothing fed today or yesterday", () => {
+        expect(
+            computeFeedingStreak([{ fedAt: dayAt(3) }], now),
+        ).toBe(0);
+    });
+
+    it("counts a 1-day streak when fed only today", () => {
+        expect(
+            computeFeedingStreak([{ fedAt: dayAt(0) }], now),
+        ).toBe(1);
+    });
+
+    it("counts back from yesterday when today has no feedings", () => {
+        expect(
+            computeFeedingStreak(
+                [{ fedAt: dayAt(1) }, { fedAt: dayAt(2) }, { fedAt: dayAt(3) }],
+                now,
+            ),
+        ).toBe(3);
+    });
+
+    it("breaks on a gap", () => {
+        // fed today, yesterday, then skip the day before, then 3 days ago.
+        expect(
+            computeFeedingStreak(
+                [
+                    { fedAt: dayAt(0) },
+                    { fedAt: dayAt(1) },
+                    { fedAt: dayAt(3) },
+                ],
+                now,
+            ),
+        ).toBe(2);
+    });
+
+    it("dedupes multiple feedings on the same day", () => {
+        expect(
+            computeFeedingStreak(
+                [
+                    { fedAt: dayAt(0) },
+                    { fedAt: dayAt(0) },
+                    { fedAt: dayAt(1) },
+                ],
+                now,
+            ),
+        ).toBe(2);
+    });
+});

--- a/src/lib/feeding-streak.ts
+++ b/src/lib/feeding-streak.ts
@@ -1,0 +1,48 @@
+export type FeedingForStreak = { fedAt: Date };
+
+/**
+ * Returns the count of consecutive days ending today (inclusive) with at
+ * least one feeding. If today has no feeding yet, the streak instead
+ * ends at yesterday (so the streak doesn't reset just because the cat
+ * hasn't been fed yet this morning). Returns 0 if neither today nor
+ * yesterday has a feeding.
+ */
+export function computeFeedingStreak(
+    feedings: ReadonlyArray<FeedingForStreak>,
+    now: Date = new Date(),
+): number {
+    if (feedings.length === 0) return 0;
+
+    const fedDays = new Set<string>();
+    for (const f of feedings) {
+        const d = f.fedAt;
+        fedDays.add(
+            `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`,
+        );
+    }
+
+    const today = new Date(now);
+    today.setHours(0, 0, 0, 0);
+    const todayKey = `${today.getFullYear()}-${today.getMonth()}-${today.getDate()}`;
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayKey = `${yesterday.getFullYear()}-${yesterday.getMonth()}-${yesterday.getDate()}`;
+
+    let cursor: Date;
+    if (fedDays.has(todayKey)) {
+        cursor = today;
+    } else if (fedDays.has(yesterdayKey)) {
+        cursor = yesterday;
+    } else {
+        return 0;
+    }
+
+    let streak = 0;
+    while (true) {
+        const key = `${cursor.getFullYear()}-${cursor.getMonth()}-${cursor.getDate()}`;
+        if (!fedDays.has(key)) break;
+        streak += 1;
+        cursor.setDate(cursor.getDate() - 1);
+    }
+    return streak;
+}

--- a/src/lib/food-breakdown.test.ts
+++ b/src/lib/food-breakdown.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    computeFoodBreakdown,
+    type FeedingForBreakdown,
+} from "./food-breakdown";
+
+const now = new Date("2026-05-14T15:00:00Z");
+const FOOD_A: FeedingForBreakdown["food"] = {
+    id: 1,
+    name: "A",
+    brand: null,
+    caloriesPerGram: 4,
+};
+const FOOD_B: FeedingForBreakdown["food"] = {
+    id: 2,
+    name: "B",
+    brand: "Acme",
+    caloriesPerGram: 3,
+};
+
+function f(
+    daysAgo: number,
+    grams: number,
+    food: FeedingForBreakdown["food"],
+): FeedingForBreakdown {
+    const d = new Date(now);
+    d.setDate(d.getDate() - daysAgo);
+    d.setHours(12, 0, 0, 0);
+    return { fedAt: d, quantityGrams: grams, food };
+}
+
+describe("computeFoodBreakdown", () => {
+    it("returns the requested number of buckets in chronological order", () => {
+        const { data } = computeFoodBreakdown([], 7, now);
+        expect(data).toHaveLength(7);
+    });
+
+    it("series is empty when there are no feedings", () => {
+        const { series } = computeFoodBreakdown([], 7, now);
+        expect(series).toEqual([]);
+    });
+
+    it("groups kcal by day and by food", () => {
+        const { data, series } = computeFoodBreakdown(
+            [
+                f(0, 50, FOOD_A),
+                f(0, 30, FOOD_B),
+                f(1, 100, FOOD_A),
+            ],
+            5,
+            now,
+        );
+        const today = data[data.length - 1]!;
+        const yesterday = data[data.length - 2]!;
+        expect(today.food_1).toBe(200);
+        expect(today.food_2).toBe(90);
+        expect(yesterday.food_1).toBe(400);
+        // Series sorted by total descending: A (600) before B (90).
+        expect(series.map((s) => s.foodId)).toEqual([1, 2]);
+        expect(series[1]!.label).toBe("Acme — B");
+    });
+
+    it("ignores feedings outside the window", () => {
+        const { data, series } = computeFoodBreakdown(
+            [f(30, 100, FOOD_A)],
+            7,
+            now,
+        );
+        expect(series).toEqual([]);
+        expect(data.every((d) => d.food_1 === undefined)).toBe(true);
+    });
+});

--- a/src/lib/food-breakdown.ts
+++ b/src/lib/food-breakdown.ts
@@ -1,0 +1,71 @@
+export type FeedingForBreakdown = {
+    fedAt: Date;
+    quantityGrams: number;
+    food: { id: number; name: string; brand: string | null; caloriesPerGram: number };
+};
+
+export type FoodSeries = {
+    foodId: number;
+    label: string;
+};
+
+export type BreakdownDay = {
+    dayKey: string;
+    dayLabel: string;
+} & Record<string, number | string>;
+
+/**
+ * Returns one entry per day for the last `days` ending today (inclusive),
+ * where each entry has the day label and one `food_<id>` key per food
+ * appearing in the window. Also returns the foods that contributed, in
+ * descending total order, so callers can render the bar series in the
+ * right order.
+ */
+export function computeFoodBreakdown(
+    feedings: ReadonlyArray<FeedingForBreakdown>,
+    days: number,
+    now: Date = new Date(),
+): { series: FoodSeries[]; data: BreakdownDay[] } {
+    const today = new Date(now);
+    today.setHours(0, 0, 0, 0);
+
+    const buckets: BreakdownDay[] = [];
+    const byKey = new Map<string, BreakdownDay>();
+    for (let i = days - 1; i >= 0; i--) {
+        const d = new Date(today);
+        d.setDate(d.getDate() - i);
+        const dayKey = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+        const dayLabel = d.toLocaleDateString(undefined, {
+            month: "short",
+            day: "numeric",
+        });
+        const bucket: BreakdownDay = { dayKey, dayLabel };
+        buckets.push(bucket);
+        byKey.set(dayKey, bucket);
+    }
+
+    const totals = new Map<number, { label: string; total: number }>();
+    for (const row of feedings) {
+        const d = row.fedAt;
+        const dayKey = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+        const bucket = byKey.get(dayKey);
+        if (!bucket) continue;
+        const kcal = row.quantityGrams * row.food.caloriesPerGram;
+        const key = `food_${row.food.id}`;
+        bucket[key] = ((bucket[key] as number | undefined) ?? 0) + kcal;
+        const existing = totals.get(row.food.id);
+        const label = row.food.brand
+            ? `${row.food.brand} — ${row.food.name}`
+            : row.food.name;
+        if (existing) {
+            existing.total += kcal;
+        } else {
+            totals.set(row.food.id, { label, total: kcal });
+        }
+    }
+
+    const series = [...totals.entries()]
+        .sort((a, b) => b[1].total - a[1].total)
+        .map(([foodId, { label }]) => ({ foodId, label }));
+    return { series, data: buckets };
+}

--- a/src/lib/weight-csv-parse.test.ts
+++ b/src/lib/weight-csv-parse.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { parseWeightCsv } from "./weight-csv-parse";
+
+describe("parseWeightCsv", () => {
+    it("rejects an empty file", () => {
+        const res = parseWeightCsv("");
+        expect(res.rows).toHaveLength(0);
+        expect(res.errors).toHaveLength(1);
+        expect(res.errors[0]!.message).toMatch(/empty/i);
+    });
+
+    it("rejects a missing header", () => {
+        const res = parseWeightCsv("foo,bar\n1,2\n");
+        expect(res.errors).toHaveLength(1);
+        expect(res.errors[0]!.message).toMatch(/header/i);
+    });
+
+    it("parses the export format", () => {
+        const csv = [
+            "entry_id,weighed_at_iso,weight,created_at_iso",
+            "1,2026-05-01T10:00:00Z,5.4,2026-05-01T10:00:01Z",
+            "2,2026-05-08T10:00:00Z,5.2,2026-05-08T10:00:01Z",
+        ].join("\n");
+        const res = parseWeightCsv(csv);
+        expect(res.errors).toHaveLength(0);
+        expect(res.rows).toHaveLength(2);
+        expect(res.rows[0]!.weight).toBeCloseTo(5.4);
+    });
+
+    it("reports invalid rows but keeps good ones", () => {
+        const csv = [
+            "weighed_at,weight",
+            "2026-05-01,5.0",
+            "not-a-date,4.9",
+            "2026-05-03,-1",
+            "2026-05-04,5.2",
+        ].join("\n");
+        const res = parseWeightCsv(csv);
+        expect(res.rows).toHaveLength(2);
+        expect(res.errors).toHaveLength(2);
+        expect(res.errors.map((e) => e.line).sort()).toEqual([3, 4]);
+    });
+
+    it("handles quoted cells with commas inside", () => {
+        const csv = [
+            'weighed_at,weight,note',
+            '2026-05-01,5.0,"hello, world"',
+        ].join("\n");
+        const res = parseWeightCsv(csv);
+        expect(res.errors).toHaveLength(0);
+        expect(res.rows).toHaveLength(1);
+    });
+});

--- a/src/lib/weight-csv-parse.ts
+++ b/src/lib/weight-csv-parse.ts
@@ -1,0 +1,111 @@
+export type ParsedWeightRow = {
+    line: number;
+    weighedAt: Date;
+    weight: number;
+};
+
+export type ParseError = {
+    line: number;
+    message: string;
+};
+
+export type ParseResult = {
+    rows: ParsedWeightRow[];
+    errors: ParseError[];
+};
+
+function splitCsvLine(line: string): string[] {
+    const out: string[] = [];
+    let cur = "";
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+        const ch = line[i]!;
+        if (inQuotes) {
+            if (ch === '"') {
+                if (line[i + 1] === '"') {
+                    cur += '"';
+                    i += 1;
+                } else {
+                    inQuotes = false;
+                }
+            } else {
+                cur += ch;
+            }
+        } else if (ch === '"') {
+            inQuotes = true;
+        } else if (ch === ",") {
+            out.push(cur);
+            cur = "";
+        } else {
+            cur += ch;
+        }
+    }
+    out.push(cur);
+    return out.map((c) => c.trim());
+}
+
+/**
+ * Parse a CSV of weight readings. Required columns: weight, and one of
+ * `weighed_at_iso` or `weighed_at` (parsed via Date()). Extra columns are
+ * ignored. Header order is detected from the first row.
+ */
+export function parseWeightCsv(text: string): ParseResult {
+    const lines = text
+        .split(/\r?\n/)
+        .map((l, i) => ({ line: i + 1, text: l }))
+        .filter((l) => l.text.trim().length > 0);
+
+    if (lines.length === 0) {
+        return { rows: [], errors: [{ line: 0, message: "Empty file" }] };
+    }
+
+    const header = splitCsvLine(lines[0]!.text).map((h) => h.toLowerCase());
+    const weightIdx = header.findIndex((h) => h === "weight");
+    const dateIdx = header.findIndex(
+        (h) =>
+            h === "weighed_at_iso" ||
+            h === "weighed_at" ||
+            h === "date" ||
+            h === "datetime",
+    );
+
+    if (weightIdx < 0 || dateIdx < 0) {
+        return {
+            rows: [],
+            errors: [
+                {
+                    line: 1,
+                    message:
+                        "Header must include 'weight' and 'weighed_at_iso' (or 'weighed_at', 'date', 'datetime').",
+                },
+            ],
+        };
+    }
+
+    const rows: ParsedWeightRow[] = [];
+    const errors: ParseError[] = [];
+    for (const { line, text: raw } of lines.slice(1)) {
+        const cells = splitCsvLine(raw);
+        const w = Number(cells[weightIdx]);
+        const dStr = cells[dateIdx];
+        if (!dStr) {
+            errors.push({ line, message: "Missing date." });
+            continue;
+        }
+        const d = new Date(dStr);
+        if (Number.isNaN(d.getTime())) {
+            errors.push({ line, message: `Invalid date: ${dStr}` });
+            continue;
+        }
+        if (!Number.isFinite(w) || w <= 0) {
+            errors.push({
+                line,
+                message: `Invalid weight: ${cells[weightIdx] ?? ""}`,
+            });
+            continue;
+        }
+        rows.push({ line, weighedAt: d, weight: w });
+    }
+
+    return { rows, errors };
+}

--- a/src/server/api/routers/pet.ts
+++ b/src/server/api/routers/pet.ts
@@ -320,6 +320,7 @@ export const petRouter = createTRPCRouter({
                 });
             }
             const token = randomUUID().replace(/-/g, "");
+            const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
             const [row] = await ctx.db
                 .insert(petInvites)
                 .values({
@@ -327,6 +328,7 @@ export const petRouter = createTRPCRouter({
                     petId: input.petId,
                     role: input.role,
                     createdBy: ctx.userId,
+                    expiresAt,
                 })
                 .returning();
             if (!row) {
@@ -336,6 +338,54 @@ export const petRouter = createTRPCRouter({
                 });
             }
             return row;
+        }),
+
+    listInvites: protectedProcedure
+        .input(getPetInput)
+        .query(async ({ ctx, input }) => {
+            const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            if (role !== "Owner") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Only the Owner can list invites.",
+                });
+            }
+            return ctx.db
+                .select()
+                .from(petInvites)
+                .where(eq(petInvites.petId, input.petId));
+        }),
+
+    revokeInvite: protectedProcedure
+        .input(z.object({ token: z.string().min(1) }))
+        .mutation(async ({ ctx, input }) => {
+            const [invite] = await ctx.db
+                .select()
+                .from(petInvites)
+                .where(eq(petInvites.token, input.token))
+                .limit(1);
+            if (!invite) {
+                throw new TRPCError({
+                    code: "NOT_FOUND",
+                    message: "Invite not found.",
+                });
+            }
+            const role = await assertPetAccess(
+                ctx.db,
+                ctx.userId,
+                invite.petId,
+            );
+            if (role !== "Owner") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Only the Owner can revoke invites.",
+                });
+            }
+            await ctx.db
+                .update(petInvites)
+                .set({ revokedAt: new Date() })
+                .where(eq(petInvites.token, input.token));
+            return { ok: true as const };
         }),
 
     acceptInvite: protectedProcedure
@@ -356,6 +406,21 @@ export const petRouter = createTRPCRouter({
                 throw new TRPCError({
                     code: "BAD_REQUEST",
                     message: "Invite already used.",
+                });
+            }
+            if (invite.revokedAt !== null) {
+                throw new TRPCError({
+                    code: "BAD_REQUEST",
+                    message: "Invite was revoked.",
+                });
+            }
+            if (
+                invite.expiresAt !== null &&
+                invite.expiresAt.getTime() < Date.now()
+            ) {
+                throw new TRPCError({
+                    code: "BAD_REQUEST",
+                    message: "Invite has expired.",
                 });
             }
             await ctx.db

--- a/src/server/api/routers/weight.ts
+++ b/src/server/api/routers/weight.ts
@@ -1,5 +1,6 @@
 import { asc, eq } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
+import { z } from "zod";
 
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { type db } from "~/server/db";
@@ -106,5 +107,40 @@ export const weightRouter = createTRPCRouter({
                 .delete(weightHistory)
                 .where(eq(weightHistory.id, input.entryId));
             return { ok: true as const };
+        }),
+
+    bulkImport: protectedProcedure
+        .input(
+            z.object({
+                petId: z.number().int().positive(),
+                entries: z
+                    .array(
+                        z.object({
+                            weighedAt: z.date(),
+                            weight: z.number().positive(),
+                        }),
+                    )
+                    .min(1)
+                    .max(1000),
+            }),
+        )
+        .mutation(async ({ ctx, input }) => {
+            const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot import entries.",
+                });
+            }
+            const rows = input.entries.map((e) => ({
+                petId: input.petId,
+                weight: e.weight,
+                weighedAt: e.weighedAt,
+            }));
+            const inserted = await ctx.db
+                .insert(weightHistory)
+                .values(rows)
+                .returning({ id: weightHistory.id });
+            return { inserted: inserted.length };
         }),
 });

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -75,6 +75,8 @@ export const petInvites = createTable(
         createdBy: varchar("created_by", { length: 256 })
             .references(() => users.id)
             .notNull(),
+        expiresAt: timestamp("expires_at", { withTimezone: true }),
+        revokedAt: timestamp("revoked_at", { withTimezone: true }),
         acceptedAt: timestamp("accepted_at", { withTimezone: true }),
         acceptedBy: varchar("accepted_by", { length: 256 }).references(
             () => users.id,

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("landing page", () => {
+    test("renders the headline and a sign-in entry point", async ({ page }) => {
+        await page.goto("/");
+        await expect(
+            page.getByRole("heading", { name: /Meow Weight Tracker/i }),
+        ).toBeVisible();
+        await expect(page.getByText(/Sign in/i)).toBeVisible();
+        await expect(page.getByRole("button", { name: /Get started/i })).toBeVisible();
+    });
+
+    test("dashboard route is protected for anonymous users", async ({
+        page,
+    }) => {
+        const response = await page.goto("/dashboard");
+        // Clerk's middleware redirects unauthenticated users to /sign-in.
+        // We assert the final URL is somewhere on the auth flow and the
+        // page rendered without crashing.
+        expect(response?.ok()).toBe(true);
+        await expect(page).toHaveURL(/\/(sign-in|$)/);
+    });
+});


### PR DESCRIPTION
## Summary
S34. Skeleton loaders on the highest-traffic loading states.

### Added
- `Skeleton` primitive (`animate-pulse rounded muted` block, accepts `className`)

### Wired
- `WeightChart` — 64h skeleton
- `KcalTrendChart` — 48h skeleton
- `WeightStatsCard` — 4-cell skeleton grid matching the stats layout
- `TodayFeedings` + `TodayActivity` — stacked row skeletons

Lower-traffic lists (history lists, food list, people page) still show "Loading…" text — fine for batch speed; easy follow-up if they ever appear during real usage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_