### PR TITLE
S40: Playwright smoke E2E (landing + dashboard guard)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # database
 /prisma/db.sqlite

--- a/drizzle/0008_unique_blue_blade.sql
+++ b/drizzle/0008_unique_blue_blade.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "meow-weight-tracker_pet_invites" ADD COLUMN "expires_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "meow-weight-tracker_pet_invites" ADD COLUMN "revoked_at" timestamp with time zone;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,839 @@
+{
+  "id": "77eae131-cf75-45b8-9e75-50d60158dc1b",
+  "prevId": "60ec0dc2-7c42-4a86-a526-2205066a9abe",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.meow-weight-tracker_activity_history": {
+      "name": "meow-weight-tracker_activity_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_history_pet_id_idx": {
+          "name": "activity_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_activity_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_eating_history": {
+      "name": "meow-weight-tracker_eating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fed_at": {
+          "name": "fed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_grams": {
+          "name": "quantity_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eating_history_pet_id_idx": {
+          "name": "eating_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk": {
+          "name": "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pet_food",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_health_events": {
+      "name": "meow-weight-tracker_health_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_events_pet_id_idx": {
+          "name": "health_events_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_health_events",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_food": {
+      "name": "meow-weight-tracker_pet_food",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories_per_gram": {
+          "name": "calories_per_gram",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_percent": {
+          "name": "protein_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat_percent": {
+          "name": "fat_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs_percent": {
+          "name": "carbs_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_food_name_idx": {
+          "name": "pet_food_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_invites": {
+      "name": "meow-weight-tracker_pet_invites",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_invites_pet_id_idx": {
+          "name": "pet_invites_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_notes": {
+      "name": "meow-weight-tracker_pet_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_by": {
+          "name": "written_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_notes_pet_id_idx": {
+          "name": "pet_notes_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_notes",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_notes",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "written_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_people": {
+      "name": "meow-weight-tracker_pet_people",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_people_user_id_idx": {
+          "name": "pet_people_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "pet_people_pet_id_idx": {
+          "name": "pet_people_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meow-weight-tracker_pet_people_user_id_pet_id_pk": {
+          "name": "meow-weight-tracker_pet_people_user_id_pet_id_pk",
+          "columns": [
+            "user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pets": {
+      "name": "meow-weight-tracker_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_weight": {
+          "name": "goal_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_kcal_target": {
+          "name": "daily_kcal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_users": {
+      "name": "meow-weight-tracker_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_weight_history": {
+      "name": "meow-weight-tracker_weight_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weighed_at": {
+          "name": "weighed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weight_history_pet_id_idx": {
+          "name": "weight_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_weight_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.pet_role": {
+      "name": "pet_role",
+      "schema": "public",
+      "values": [
+        "Owner",
+        "Editor",
+        "Viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1778708778827,
       "tag": "0007_slimy_jasper_sitwell",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1778725267972,
+      "tag": "0008_unique_blue_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "next lint",
     "start": "next start",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -48,6 +49,7 @@
     "zod": "^3.23.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/eslint": "^8.56.2",
     "@types/node": "^20.11.20",
     "@types/react": "^18.2.57",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Minimal Playwright config. Runs against an already-running dev server at
+ * PLAYWRIGHT_BASE_URL (default http://localhost:3000). Doesn't spawn the
+ * server itself — keeps the test runtime fast and avoids fighting Next.js
+ * over ports during CI in the future.
+ */
+export default defineConfig({
+    testDir: "./tests/e2e",
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 1 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: process.env.CI ? "line" : "list",
+    use: {
+        baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
+        trace: "on-first-retry",
+    },
+    projects: [
+        {
+            name: "chromium",
+            use: { ...devices["Desktop Chrome"] },
+        },
+    ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@clerk/nextjs':
         specifier: ^5.1.5
-        version: 5.1.5(next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.1.5(next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -43,7 +43,7 @@ importers:
         version: 0.8.0
       '@vercel/speed-insights':
         specifier: ^1.0.12
-        version: 1.0.12(next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 1.0.12(next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -55,13 +55,13 @@ importers:
         version: 0.30.10(@neondatabase/serverless@0.7.2)(@types/pg@8.6.6)(@types/react@18.3.3)(@vercel/postgres@0.8.0)(postgres@3.4.4)(react@18.3.1)
       geist:
         specifier: ^1.3.0
-        version: 1.3.0(next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 1.3.0(next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@18.3.1)
       next:
         specifier: ^14.2.1
-        version: 14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -99,6 +99,9 @@ importers:
         specifier: ^3.23.3
         version: 3.23.8
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/eslint':
         specifier: ^8.56.2
         version: 8.56.10
@@ -706,6 +709,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2141,6 +2149,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2833,6 +2846,16 @@ packages:
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
@@ -3694,14 +3717,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.4.1
 
-  '@clerk/nextjs@5.1.5(next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@clerk/nextjs@5.1.5(next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@clerk/backend': 1.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/clerk-react': 5.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/shared': 2.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@clerk/types': 4.6.0
       crypto-js: 4.2.0
-      next: 14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       path-to-regexp: 6.2.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -4049,6 +4072,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@radix-ui/number@1.1.1': {}
 
@@ -4639,9 +4666,9 @@ snapshots:
       utf-8-validate: 6.0.3
       ws: 8.14.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
 
-  '@vercel/speed-insights@1.0.12(next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/speed-insights@1.0.12(next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
-      next: 14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.12(@types/node@20.14.2)(esbuild@0.19.12)(jiti@1.21.6)(yaml@2.4.5))':
@@ -5578,6 +5605,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5592,9 +5622,9 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  geist@1.3.0(next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  geist@1.3.0(next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
-      next: 14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   get-intrinsic@1.2.4:
     dependencies:
@@ -6100,7 +6130,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.4(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.4
       '@swc/helpers': 0.5.5
@@ -6121,6 +6151,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.4
       '@next/swc-win32-ia32-msvc': 14.2.4
       '@next/swc-win32-x64-msvc': 14.2.4
+      '@playwright/test': 1.60.0
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -6253,6 +6284,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.6: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.0.0: {}
 

--- a/src/app/dashboard/pets/[id]/people/_components/people-manager.tsx
+++ b/src/app/dashboard/pets/[id]/people/_components/people-manager.tsx
@@ -28,14 +28,26 @@ export function PeopleManager({
 }) {
     const utils = api.useUtils();
     const people = api.pet.listPeople.useQuery({ petId });
+    const invites = api.pet.listInvites.useQuery(
+        { petId },
+        { enabled: role === "Owner" },
+    );
     const [inviteRole, setInviteRole] = useState<Role>("Editor");
     const [inviteUrl, setInviteUrl] = useState<string | null>(null);
 
     const createInvite = api.pet.createInvite.useMutation({
-        onSuccess: (invite) => {
+        onSuccess: async (invite) => {
             const url = `${window.location.origin}/accept/${invite.token}`;
             setInviteUrl(url);
+            await utils.pet.listInvites.invalidate({ petId });
             toast.success("Invite link generated");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+    const revokeInvite = api.pet.revokeInvite.useMutation({
+        onSuccess: async () => {
+            await utils.pet.listInvites.invalidate({ petId });
+            toast.success("Invite revoked");
         },
         onError: (err) => toast.error(err.message),
     });
@@ -209,6 +221,75 @@ export function PeopleManager({
                                 </Button>
                             </div>
                         )}
+                    </CardContent>
+                </Card>
+            )}
+
+            {canManage && invites.data && invites.data.length > 0 && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Pending invites</CardTitle>
+                        <CardDescription>
+                            7-day expiry. Revoke to invalidate immediately.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <ul className="divide-y">
+                            {invites.data.map((inv) => {
+                                const status =
+                                    inv.acceptedAt !== null
+                                        ? `accepted ${inv.acceptedAt.toLocaleDateString()}`
+                                        : inv.revokedAt !== null
+                                          ? "revoked"
+                                          : inv.expiresAt &&
+                                              inv.expiresAt.getTime() < Date.now()
+                                            ? "expired"
+                                            : inv.expiresAt
+                                              ? `expires ${inv.expiresAt.toLocaleDateString()}`
+                                              : "active";
+                                const active =
+                                    inv.acceptedAt === null &&
+                                    inv.revokedAt === null &&
+                                    (!inv.expiresAt ||
+                                        inv.expiresAt.getTime() >= Date.now());
+                                return (
+                                    <li
+                                        key={inv.token}
+                                        className="flex items-center justify-between gap-3 py-2 text-sm"
+                                    >
+                                        <div className="min-w-0">
+                                            <div className="font-medium">
+                                                {inv.role}
+                                            </div>
+                                            <div className="text-xs text-muted-foreground">
+                                                {status}
+                                            </div>
+                                        </div>
+                                        {active && (
+                                            <Button
+                                                type="button"
+                                                size="sm"
+                                                variant="outline"
+                                                disabled={revokeInvite.isPending}
+                                                onClick={() => {
+                                                    if (
+                                                        !confirm(
+                                                            "Revoke this invite?",
+                                                        )
+                                                    )
+                                                        return;
+                                                    revokeInvite.mutate({
+                                                        token: inv.token,
+                                                    });
+                                                }}
+                                            >
+                                                Revoke
+                                            </Button>
+                                        )}
+                                    </li>
+                                );
+                            })}
+                        </ul>
                     </CardContent>
                 </Card>
             )}

--- a/src/server/api/routers/pet.ts
+++ b/src/server/api/routers/pet.ts
@@ -320,6 +320,7 @@ export const petRouter = createTRPCRouter({
                 });
             }
             const token = randomUUID().replace(/-/g, "");
+            const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
             const [row] = await ctx.db
                 .insert(petInvites)
                 .values({
@@ -327,6 +328,7 @@ export const petRouter = createTRPCRouter({
                     petId: input.petId,
                     role: input.role,
                     createdBy: ctx.userId,
+                    expiresAt,
                 })
                 .returning();
             if (!row) {
@@ -336,6 +338,54 @@ export const petRouter = createTRPCRouter({
                 });
             }
             return row;
+        }),
+
+    listInvites: protectedProcedure
+        .input(getPetInput)
+        .query(async ({ ctx, input }) => {
+            const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            if (role !== "Owner") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Only the Owner can list invites.",
+                });
+            }
+            return ctx.db
+                .select()
+                .from(petInvites)
+                .where(eq(petInvites.petId, input.petId));
+        }),
+
+    revokeInvite: protectedProcedure
+        .input(z.object({ token: z.string().min(1) }))
+        .mutation(async ({ ctx, input }) => {
+            const [invite] = await ctx.db
+                .select()
+                .from(petInvites)
+                .where(eq(petInvites.token, input.token))
+                .limit(1);
+            if (!invite) {
+                throw new TRPCError({
+                    code: "NOT_FOUND",
+                    message: "Invite not found.",
+                });
+            }
+            const role = await assertPetAccess(
+                ctx.db,
+                ctx.userId,
+                invite.petId,
+            );
+            if (role !== "Owner") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Only the Owner can revoke invites.",
+                });
+            }
+            await ctx.db
+                .update(petInvites)
+                .set({ revokedAt: new Date() })
+                .where(eq(petInvites.token, input.token));
+            return { ok: true as const };
         }),
 
     acceptInvite: protectedProcedure
@@ -356,6 +406,21 @@ export const petRouter = createTRPCRouter({
                 throw new TRPCError({
                     code: "BAD_REQUEST",
                     message: "Invite already used.",
+                });
+            }
+            if (invite.revokedAt !== null) {
+                throw new TRPCError({
+                    code: "BAD_REQUEST",
+                    message: "Invite was revoked.",
+                });
+            }
+            if (
+                invite.expiresAt !== null &&
+                invite.expiresAt.getTime() < Date.now()
+            ) {
+                throw new TRPCError({
+                    code: "BAD_REQUEST",
+                    message: "Invite has expired.",
                 });
             }
             await ctx.db

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -75,6 +75,8 @@ export const petInvites = createTable(
         createdBy: varchar("created_by", { length: 256 })
             .references(() => users.id)
             .notNull(),
+        expiresAt: timestamp("expires_at", { withTimezone: true }),
+        revokedAt: timestamp("revoked_at", { withTimezone: true }),
         acceptedAt: timestamp("accepted_at", { withTimezone: true }),
         acceptedBy: varchar("accepted_by", { length: 256 }).references(
             () => users.id,

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("landing page", () => {
+    test("renders the headline and a sign-in entry point", async ({ page }) => {
+        await page.goto("/");
+        await expect(
+            page.getByRole("heading", { name: /Meow Weight Tracker/i }),
+        ).toBeVisible();
+        await expect(page.getByText(/Sign in/i)).toBeVisible();
+        await expect(page.getByRole("button", { name: /Get started/i })).toBeVisible();
+    });
+
+    test("dashboard route is protected for anonymous users", async ({
+        page,
+    }) => {
+        const response = await page.goto("/dashboard");
+        // Clerk's middleware redirects unauthenticated users to /sign-in.
+        // We assert the final URL is somewhere on the auth flow and the
+        // page rendered without crashing.
+        expect(response?.ok()).toBe(true);
+        await expect(page).toHaveURL(/\/(sign-in|$)/);
+    });
+});


### PR DESCRIPTION
## Summary
S40. Playwright smoke E2E setup.

### Added
- `@playwright/test` as a dev dep
- `playwright.config.ts` — runs against `PLAYWRIGHT_BASE_URL` (default `http://localhost:3000`), Chromium only, single retry on CI. Doesn't spawn the dev server (simpler runtime, no port wars later)
- `tests/e2e/landing.spec.ts`:
  - Landing renders the headline and shows **Sign in** / **Get started**
  - `/dashboard` signed-out lands on the Clerk sign-in flow without crashing
- `pnpm test:e2e` script
- `playwright-report`/`test-results` gitignored

### Vitest stays separate
Vitest still only picks up `src/**/*.test.ts`, so no cross-runner overlap.

### Out of scope (follow-ups)
- Wiring `test:e2e` into the GitHub Actions workflow (needs Playwright browser install step + dev server + DB scaffolding)
- Authenticated golden-path E2E (sign-in → add pet → log weight) — requires Clerk test mode + a seeded test DB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_