### PR TITLE
S42: photo upload via @vercel/blob

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@trpc/client": "next",
     "@trpc/react-query": "next",
     "@trpc/server": "next",
+    "@vercel/blob": "^2.3.3",
     "@vercel/postgres": "^0.8.0",
     "@vercel/speed-insights": "^1.0.12",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@trpc/server':
         specifier: next
         version: 11.0.0-rc.403
+      '@vercel/blob':
+        specifier: ^2.3.3
+        version: 2.3.3
       '@vercel/postgres':
         specifier: ^0.8.0
         version: 0.8.0
@@ -1353,6 +1356,10 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
+  '@vercel/blob@2.3.3':
+    resolution: {integrity: sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==}
+    engines: {node: '>=20.0.0'}
+
   '@vercel/postgres@0.8.0':
     resolution: {integrity: sha512-/QUV9ExwaNdKooRjOQqvrKNVnRvsaXeukPNI5DB1ovUTesglfR/fparw7ngo1KUWWKIVpEj2TRrA+ObRHRdaLg==}
     engines: {node: '>=14.6'}
@@ -1516,6 +1523,9 @@ packages:
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -2328,6 +2338,10 @@ packages:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
     engines: {node: '>= 0.4'}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -2369,6 +2383,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
@@ -3111,6 +3128,10 @@ packages:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -3340,6 +3361,10 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
   timers-ext@0.1.8:
     resolution: {integrity: sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==}
     engines: {node: '>=0.12'}
@@ -3440,6 +3465,10 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
 
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
@@ -4659,6 +4688,14 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
+  '@vercel/blob@2.3.3':
+    dependencies:
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.25.0
+
   '@vercel/postgres@0.8.0':
     dependencies:
       '@neondatabase/serverless': 0.7.2
@@ -4836,6 +4873,10 @@ snapshots:
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -5798,6 +5839,8 @@ snapshots:
       call-bind: 1.0.7
       has-tostringtag: 1.0.2
 
+  is-buffer@2.0.5: {}
+
   is-callable@1.2.7: {}
 
   is-core-module@2.13.1:
@@ -5831,6 +5874,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.0.7:
     dependencies:
@@ -6495,6 +6540,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.13.1: {}
+
   reusify@1.0.4: {}
 
   rimraf@3.0.2:
@@ -6770,6 +6817,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  throttleit@2.1.0: {}
+
   timers-ext@0.1.8:
     dependencies:
       es5-ext: 0.10.64
@@ -6875,6 +6924,8 @@ snapshots:
       which-boxed-primitive: 1.0.2
 
   undici-types@5.26.5: {}
+
+  undici@6.25.0: {}
 
   undici@7.25.0: {}
 

--- a/src/app/api/pets/[id]/photo/route.ts
+++ b/src/app/api/pets/[id]/photo/route.ts
@@ -1,0 +1,66 @@
+import { auth } from "@clerk/nextjs/server";
+import { put } from "@vercel/blob";
+
+import { db } from "~/server/db";
+import { env } from "~/env";
+import { assertPetAccess } from "~/server/api/petAccess";
+
+export const dynamic = "force-dynamic";
+
+const MAX_BYTES = 5 * 1024 * 1024;
+const ALLOWED = new Set([
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "image/gif",
+]);
+
+export async function POST(req: Request) {
+    const { userId } = auth();
+    if (!userId) return new Response("Unauthorized", { status: 401 });
+
+    if (!env.BLOB_READ_WRITE_TOKEN) {
+        return new Response(
+            "BLOB_READ_WRITE_TOKEN not configured. Upload disabled.",
+            { status: 500 },
+        );
+    }
+
+    const form = await req.formData();
+    const file = form.get("file");
+    const petIdRaw = form.get("petId");
+    if (!(file instanceof File) || typeof petIdRaw !== "string") {
+        return new Response("Bad request", { status: 400 });
+    }
+    const petId = Number(petIdRaw);
+    if (!Number.isFinite(petId) || petId <= 0) {
+        return new Response("Bad petId", { status: 400 });
+    }
+    if (file.size === 0 || file.size > MAX_BYTES) {
+        return new Response(
+            `Image must be 1 byte to ${MAX_BYTES / (1024 * 1024)} MB`,
+            { status: 413 },
+        );
+    }
+    if (!ALLOWED.has(file.type)) {
+        return new Response(
+            "Unsupported file type. Use JPEG, PNG, WebP, or GIF.",
+            { status: 415 },
+        );
+    }
+
+    const role = await assertPetAccess(db, userId, petId).catch(() => null);
+    if (role === null || role === "Viewer") {
+        return new Response("Forbidden", { status: 403 });
+    }
+
+    const ext = file.name.split(".").pop()?.toLowerCase() ?? "jpg";
+    const key = `pet-photos/${petId}/${Date.now()}.${ext}`;
+    const blob = await put(key, file, {
+        access: "public",
+        contentType: file.type,
+        token: env.BLOB_READ_WRITE_TOKEN,
+    });
+
+    return Response.json({ url: blob.url });
+}

--- a/src/app/dashboard/pets/[id]/_components/pet-edit-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/pet-edit-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useRef, useState, type FormEvent } from "react";
 import { Pencil } from "lucide-react";
 import { toast } from "sonner";
 
@@ -33,6 +33,33 @@ export function PetEditCard({ pet }: { pet: Pet }) {
         pet.dailyKcalTarget !== null ? String(pet.dailyKcalTarget) : "",
     );
     const [photoUrl, setPhotoUrl] = useState(pet.photoUrl ?? "");
+    const [uploading, setUploading] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    async function onUpload(file: File) {
+        setUploading(true);
+        try {
+            const form = new FormData();
+            form.set("file", file);
+            form.set("petId", String(pet.id));
+            const res = await fetch(`/api/pets/${pet.id}/photo`, {
+                method: "POST",
+                body: form,
+            });
+            if (!res.ok) {
+                const msg = await res.text();
+                toast.error(msg || "Upload failed");
+                return;
+            }
+            const data = (await res.json()) as { url: string };
+            setPhotoUrl(data.url);
+            toast.success("Photo uploaded");
+        } catch (err) {
+            toast.error(err instanceof Error ? err.message : "Upload failed");
+        } finally {
+            setUploading(false);
+        }
+    }
 
     const utils = api.useUtils();
     const updatePet = api.pet.updatePet.useMutation({
@@ -184,14 +211,39 @@ export function PetEditCard({ pet }: { pet: Pet }) {
                             </div>
                         </div>
                         <div className="space-y-1">
-                            <Label htmlFor="edit-photo">Photo URL</Label>
-                            <Input
-                                id="edit-photo"
-                                type="url"
-                                value={photoUrl}
-                                onChange={(e) => setPhotoUrl(e.target.value)}
-                                placeholder="https://…"
-                            />
+                            <Label htmlFor="edit-photo">Photo</Label>
+                            <div className="flex gap-2">
+                                <Input
+                                    id="edit-photo"
+                                    type="url"
+                                    value={photoUrl}
+                                    onChange={(e) => setPhotoUrl(e.target.value)}
+                                    placeholder="https://… or upload a file"
+                                />
+                                <input
+                                    ref={fileInputRef}
+                                    type="file"
+                                    accept="image/jpeg,image/png,image/webp,image/gif"
+                                    className="hidden"
+                                    onChange={(e) => {
+                                        const f = e.target.files?.[0];
+                                        if (f) void onUpload(f);
+                                        if (fileInputRef.current)
+                                            fileInputRef.current.value = "";
+                                    }}
+                                />
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="outline"
+                                    disabled={uploading}
+                                    onClick={() =>
+                                        fileInputRef.current?.click()
+                                    }
+                                >
+                                    {uploading ? "Uploading…" : "Upload"}
+                                </Button>
+                            </div>
                         </div>
                         {updatePet.error && (
                             <p className="text-sm text-destructive">

--- a/src/env.js
+++ b/src/env.js
@@ -12,6 +12,7 @@ export const env = createEnv({
       .enum(["development", "test", "production"])
       .default("development"),
     CLERK_WEBHOOK_SECRET: z.string().optional(),
+    BLOB_READ_WRITE_TOKEN: z.string().optional(),
   },
 
   /**
@@ -31,6 +32,7 @@ export const env = createEnv({
     POSTGRES_URL: process.env.POSTGRES_URL,
     NODE_ENV: process.env.NODE_ENV,
     CLERK_WEBHOOK_SECRET: process.env.CLERK_WEBHOOK_SECRET,
+    BLOB_READ_WRITE_TOKEN: process.env.BLOB_READ_WRITE_TOKEN,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
   },
   /**


### PR DESCRIPTION
## Summary
S42 (first of Batch 5). Real file upload for pet photos using `@vercel/blob`.

### Server
- `POST /api/pets/[id]/photo` — Clerk auth + `assertPetAccess` (Viewer blocked), 5MB cap, JPEG/PNG/WebP/GIF only, returns `{ url }`
- Key pattern: `pet-photos/<petId>/<timestamp>.<ext>`, public access
- `BLOB_READ_WRITE_TOKEN` added as an **optional** server env. Route returns 500 with a clear message if missing — rest of the app keeps building

### UI
- `PetEditCard` photo field now has a paired file picker. Choosing a file uploads via `FormData`, populates the URL input on success, then the normal Save flow writes `pets.photoUrl`. URL input still editable for paste-a-URL use cases.

### Config note
For local dev / preview deploys, set `BLOB_READ_WRITE_TOKEN` from the Vercel Blob dashboard. Without it, upload returns 500 but URL paste still works.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_