### PR TITLE
S44: 365-day feeding heatmap

### DIFF
--- a/src/app/dashboard/pets/[id]/_components/feeding-heatmap-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/feeding-heatmap-card.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useMemo } from "react";
+
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
+import { computeFeedingHeatmap } from "~/lib/feeding-heatmap";
+import { cn } from "~/lib/utils";
+import { api } from "~/trpc/react";
+
+const LEVEL_CLASSES: Record<0 | 1 | 2 | 3 | 4, string> = {
+    0: "bg-muted",
+    1: "bg-orange-200 dark:bg-orange-900/40",
+    2: "bg-orange-300 dark:bg-orange-800/60",
+    3: "bg-orange-400 dark:bg-orange-700/80",
+    4: "bg-orange-500 dark:bg-orange-600",
+};
+
+export function FeedingHeatmapCard({ petId }: { petId: number }) {
+    const { data, isLoading } = api.feeding.getFeedingHistory.useQuery({
+        petId,
+    });
+    const { cells, total } = useMemo(
+        () => computeFeedingHeatmap(data ?? [], 365),
+        [data],
+    );
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Feeding heatmap</CardTitle>
+                <CardDescription>
+                    Last 12 months · {total}{" "}
+                    {total === 1 ? "feeding" : "feedings"} logged
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <Skeleton className="h-24 w-full" />
+                ) : (
+                    <div className="overflow-x-auto">
+                        <div className="flex gap-[2px]">
+                            {cells.map((week, wi) => (
+                                <div
+                                    key={wi}
+                                    className="flex flex-col gap-[2px]"
+                                >
+                                    {week.map((cell) => (
+                                        <div
+                                            key={cell.dayKey}
+                                            title={`${cell.date.toLocaleDateString()}: ${cell.count} ${cell.count === 1 ? "feeding" : "feedings"}`}
+                                            className={cn(
+                                                "h-2.5 w-2.5 rounded-[2px]",
+                                                LEVEL_CLASSES[cell.level],
+                                            )}
+                                        />
+                                    ))}
+                                </div>
+                            ))}
+                        </div>
+                        <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+                            <span>Less</span>
+                            {[0, 1, 2, 3, 4].map((l) => (
+                                <span
+                                    key={l}
+                                    className={cn(
+                                        "h-2.5 w-2.5 rounded-[2px]",
+                                        LEVEL_CLASSES[l as 0 | 1 | 2 | 3 | 4],
+                                    )}
+                                />
+                            ))}
+                            <span>More</span>
+                        </div>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -8,6 +8,7 @@ import { PetEditCard } from "~/app/dashboard/pets/[id]/_components/pet-edit-card
 import { FeedingHistoryList } from "~/app/dashboard/pets/[id]/_components/feeding-history-list";
 import { WeightHistoryList } from "~/app/dashboard/pets/[id]/_components/weight-history-list";
 import { ExportCard } from "~/app/dashboard/pets/[id]/_components/export-card";
+import { FeedingHeatmapCard } from "~/app/dashboard/pets/[id]/_components/feeding-heatmap-card";
 import { HealthEventsCard } from "~/app/dashboard/pets/[id]/_components/health-events-card";
 import { NotesCard } from "~/app/dashboard/pets/[id]/_components/notes-card";
 import { ImportWeightCard } from "~/app/dashboard/pets/[id]/_components/import-weight-card";
@@ -63,6 +64,7 @@ export default async function PetDetailPage({
                 goalWeight={pet.goalWeight}
             />
             <WeightHistoryList petId={pet.id} canEdit={pet.role !== "Viewer"} />
+            <FeedingHeatmapCard petId={pet.id} />
             <FeedingHistoryList petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <HealthEventsCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <NotesCard petId={pet.id} canEdit={pet.role !== "Viewer"} />

--- a/src/lib/feeding-heatmap.test.ts
+++ b/src/lib/feeding-heatmap.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { computeFeedingHeatmap } from "./feeding-heatmap";
+
+const now = new Date("2026-05-14T15:00:00Z");
+const at = (daysAgo: number) => {
+    const d = new Date(now);
+    d.setDate(d.getDate() - daysAgo);
+    d.setHours(12, 0, 0, 0);
+    return { fedAt: d };
+};
+
+describe("computeFeedingHeatmap", () => {
+    it("returns full weeks of 7 cells", () => {
+        const { cells } = computeFeedingHeatmap([], 30, now);
+        for (const week of cells) {
+            expect(week).toHaveLength(7);
+        }
+    });
+
+    it("totals match input within the window", () => {
+        const { total } = computeFeedingHeatmap(
+            [at(0), at(0), at(2), at(500)],
+            30,
+            now,
+        );
+        expect(total).toBe(3); // 500d ago is outside the 30d window
+    });
+
+    it("level 0 for zero days, >0 for active days", () => {
+        const { cells } = computeFeedingHeatmap([at(0)], 7, now);
+        const flat = cells.flat();
+        expect(flat.filter((c) => c.count > 0)).toHaveLength(1);
+        expect(flat.filter((c) => c.level === 0).length).toBeGreaterThan(0);
+        expect(flat.find((c) => c.count > 0)!.level).toBeGreaterThan(0);
+    });
+
+    it("scales levels relative to busiest day", () => {
+        const feedings = [
+            at(0),
+            at(0),
+            at(0),
+            at(0), // busiest = 4
+            at(1), // 25% -> 1
+            at(2),
+            at(2), // 50% -> 3
+        ];
+        const { cells, busiest } = computeFeedingHeatmap(feedings, 7, now);
+        expect(busiest).toBe(4);
+        const flat = cells.flat();
+        const today = flat.find((c) => c.count === 4)!;
+        const yest = flat.find((c) => c.count === 1)!;
+        const twoAgo = flat.find((c) => c.count === 2)!;
+        expect(today.level).toBe(4);
+        // 1/4 = 0.25 → at the 25% boundary, bucket 2.
+        expect(yest.level).toBe(2);
+        // 2/4 = 0.5 → at the 50% boundary, bucket 3.
+        expect(twoAgo.level).toBe(3);
+    });
+});

--- a/src/lib/feeding-heatmap.ts
+++ b/src/lib/feeding-heatmap.ts
@@ -1,0 +1,75 @@
+export type FeedingForHeatmap = { fedAt: Date };
+
+export type HeatmapCell = {
+    date: Date;
+    dayKey: string;
+    count: number;
+    /** 0-4 intensity bucket; 0 = no feedings */
+    level: 0 | 1 | 2 | 3 | 4;
+};
+
+/**
+ * Build a fixed-size heatmap grid for the last `days` days, ending today.
+ * Output is one column per ISO week (Mon..Sun rows), oldest column first.
+ * `level` buckets the count into 5 intensities (0..4) so the UI can pick a
+ * fixed palette.
+ */
+export function computeFeedingHeatmap(
+    feedings: ReadonlyArray<FeedingForHeatmap>,
+    days = 365,
+    now: Date = new Date(),
+): { cells: HeatmapCell[][]; total: number; busiest: number } {
+    const today = new Date(now);
+    today.setHours(0, 0, 0, 0);
+
+    const start = new Date(today);
+    start.setDate(start.getDate() - (days - 1));
+    // Walk back to the Monday on or before `start` so columns are full weeks.
+    const startDay = (start.getDay() + 6) % 7; // 0 = Mon ... 6 = Sun
+    start.setDate(start.getDate() - startDay);
+
+    const cutoffStart = start.getTime();
+    const cutoffEnd = today.getTime() + 24 * 60 * 60 * 1000;
+
+    const counts = new Map<string, number>();
+    let total = 0;
+    for (const row of feedings) {
+        const t = row.fedAt.getTime();
+        if (t < cutoffStart || t >= cutoffEnd) continue;
+        const d = row.fedAt;
+        const key = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+        total += 1;
+    }
+    const busiest = counts.size === 0 ? 0 : Math.max(...counts.values());
+
+    const cells: HeatmapCell[][] = [];
+    const cursor = new Date(start);
+    while (cursor.getTime() <= today.getTime()) {
+        const week: HeatmapCell[] = [];
+        for (let i = 0; i < 7; i++) {
+            const date = new Date(cursor);
+            const key = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+            const count = counts.get(key) ?? 0;
+            week.push({
+                date,
+                dayKey: key,
+                count,
+                level: bucket(count, busiest),
+            });
+            cursor.setDate(cursor.getDate() + 1);
+        }
+        cells.push(week);
+    }
+    return { cells, total, busiest };
+}
+
+function bucket(count: number, busiest: number): 0 | 1 | 2 | 3 | 4 {
+    if (count === 0) return 0;
+    if (busiest <= 1) return 1;
+    const ratio = count / busiest;
+    if (ratio >= 0.75) return 4;
+    if (ratio >= 0.5) return 3;
+    if (ratio >= 0.25) return 2;
+    return 1;
+}


### PR DESCRIPTION
## Summary
S44. GitHub-style 12-month feeding heatmap on the pet detail page.

### Compute
- `computeFeedingHeatmap` (`~/lib/feeding-heatmap.ts`). Builds a fixed grid of full ISO weeks (Mon..Sun rows) ending today, buckets per-day count into 5 intensity levels (0..4) relative to the busiest day. 4 tests.

### UI
- `FeedingHeatmapCard` — orange palette, tuned for both themes; per-cell title shows date + count; Less/More legend.
- Pulled in via `/dashboard/pets/[id]` between the weight history list and the feeding history list.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_