### PR TITLE
S45: recurring medications with due tracking

### DIFF
--- a/drizzle/0009_special_scorpion.sql
+++ b/drizzle/0009_special_scorpion.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS "meow-weight-tracker_pet_meds" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"pet_id" integer NOT NULL,
+	"name" varchar(256) NOT NULL,
+	"dosage" varchar(128),
+	"frequency_hours" integer NOT NULL,
+	"starts_at" timestamp with time zone NOT NULL,
+	"ends_at" timestamp with time zone,
+	"last_given_at" timestamp with time zone,
+	"notes" varchar(1024),
+	"deleted_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "meow-weight-tracker_pet_meds" ADD CONSTRAINT "meow-weight-tracker_pet_meds_pet_id_meow-weight-tracker_pets_id_fk" FOREIGN KEY ("pet_id") REFERENCES "public"."meow-weight-tracker_pets"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "pet_meds_pet_id_idx" ON "meow-weight-tracker_pet_meds" ("pet_id");

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,945 @@
+{
+  "id": "12e3a920-50e8-4846-8a75-b49bd99b76a5",
+  "prevId": "77eae131-cf75-45b8-9e75-50d60158dc1b",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.meow-weight-tracker_activity_history": {
+      "name": "meow-weight-tracker_activity_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_history_pet_id_idx": {
+          "name": "activity_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_activity_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_eating_history": {
+      "name": "meow-weight-tracker_eating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fed_at": {
+          "name": "fed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_grams": {
+          "name": "quantity_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eating_history_pet_id_idx": {
+          "name": "eating_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk": {
+          "name": "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pet_food",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_health_events": {
+      "name": "meow-weight-tracker_health_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_events_pet_id_idx": {
+          "name": "health_events_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_health_events",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_food": {
+      "name": "meow-weight-tracker_pet_food",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories_per_gram": {
+          "name": "calories_per_gram",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_percent": {
+          "name": "protein_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat_percent": {
+          "name": "fat_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs_percent": {
+          "name": "carbs_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_food_name_idx": {
+          "name": "pet_food_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_invites": {
+      "name": "meow-weight-tracker_pet_invites",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_invites_pet_id_idx": {
+          "name": "pet_invites_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_meds": {
+      "name": "meow-weight-tracker_pet_meds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_hours": {
+          "name": "frequency_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_given_at": {
+          "name": "last_given_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_meds_pet_id_idx": {
+          "name": "pet_meds_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_meds_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_meds_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_meds",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_notes": {
+      "name": "meow-weight-tracker_pet_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_by": {
+          "name": "written_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_notes_pet_id_idx": {
+          "name": "pet_notes_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_notes",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_notes",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "written_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_people": {
+      "name": "meow-weight-tracker_pet_people",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_people_user_id_idx": {
+          "name": "pet_people_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "pet_people_pet_id_idx": {
+          "name": "pet_people_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meow-weight-tracker_pet_people_user_id_pet_id_pk": {
+          "name": "meow-weight-tracker_pet_people_user_id_pet_id_pk",
+          "columns": [
+            "user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pets": {
+      "name": "meow-weight-tracker_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_weight": {
+          "name": "goal_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_kcal_target": {
+          "name": "daily_kcal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_users": {
+      "name": "meow-weight-tracker_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_weight_history": {
+      "name": "meow-weight-tracker_weight_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weighed_at": {
+          "name": "weighed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weight_history_pet_id_idx": {
+          "name": "weight_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_weight_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.pet_role": {
+      "name": "pet_role",
+      "schema": "public",
+      "values": [
+        "Owner",
+        "Editor",
+        "Viewer"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1778725267972,
       "tag": "0008_unique_blue_blade",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1778730759080,
+      "tag": "0009_special_scorpion",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/dashboard/pets/[id]/_components/meds-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/meds-card.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Check, Pill, Plus, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "~/components/ui/dialog";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { isMedDue, nextDueAt } from "~/lib/meds-due";
+import { cn } from "~/lib/utils";
+import { api } from "~/trpc/react";
+
+export function MedsCard({
+    petId,
+    canEdit,
+}: {
+    petId: number;
+    canEdit: boolean;
+}) {
+    const utils = api.useUtils();
+    const { data, isLoading } = api.meds.list.useQuery({ petId });
+    const [open, setOpen] = useState(false);
+    const [name, setName] = useState("");
+    const [dosage, setDosage] = useState("");
+    const [frequencyHours, setFrequencyHours] = useState("12");
+    const [startsAt, setStartsAt] = useState("");
+    const [endsAt, setEndsAt] = useState("");
+    const [notes, setNotes] = useState("");
+
+    const create = api.meds.create.useMutation({
+        onSuccess: async () => {
+            await utils.meds.list.invalidate({ petId });
+            setOpen(false);
+            setName("");
+            setDosage("");
+            setEndsAt("");
+            setNotes("");
+            toast.success("Medication added");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+    const markGiven = api.meds.markGiven.useMutation({
+        onSuccess: async () => {
+            await utils.meds.list.invalidate({ petId });
+            toast.success("Marked given");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+    const deleteEntry = api.meds.deleteEntry.useMutation({
+        onSuccess: async () => {
+            await utils.meds.list.invalidate({ petId });
+            toast.success("Medication removed");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+
+    function onSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        const freq = Number(frequencyHours);
+        if (!Number.isFinite(freq) || freq <= 0) return;
+        const sa = startsAt ? new Date(startsAt) : new Date();
+        create.mutate({
+            petId,
+            name: name.trim(),
+            frequencyHours: Math.round(freq),
+            startsAt: sa,
+            ...(dosage.trim() ? { dosage: dosage.trim() } : {}),
+            ...(endsAt ? { endsAt: new Date(endsAt) } : {}),
+            ...(notes.trim() ? { notes: notes.trim() } : {}),
+        });
+    }
+
+    const dueCount = (data ?? []).filter((m) =>
+        isMedDue({
+            startsAt: m.startsAt,
+            endsAt: m.endsAt,
+            lastGivenAt: m.lastGivenAt,
+            frequencyHours: m.frequencyHours,
+        }),
+    ).length;
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                <div>
+                    <CardTitle className="flex items-center gap-2">
+                        <Pill className="h-4 w-4" />
+                        Medications
+                        {dueCount > 0 && (
+                            <span className="rounded-full bg-destructive/15 px-2 py-0.5 text-[10px] font-medium text-destructive">
+                                {dueCount} due
+                            </span>
+                        )}
+                    </CardTitle>
+                    <CardDescription>
+                        Recurring doses with a next-due reminder.
+                    </CardDescription>
+                </div>
+                {canEdit && (
+                    <Dialog open={open} onOpenChange={setOpen}>
+                        <DialogTrigger asChild>
+                            <Button type="button" size="sm" variant="outline">
+                                <Plus className="mr-1 h-3.5 w-3.5" />
+                                Add med
+                            </Button>
+                        </DialogTrigger>
+                        <DialogContent>
+                            <DialogHeader>
+                                <DialogTitle>Add medication</DialogTitle>
+                            </DialogHeader>
+                            <form onSubmit={onSubmit} className="space-y-3">
+                                <div className="space-y-1">
+                                    <Label htmlFor="med-name">Name</Label>
+                                    <Input
+                                        id="med-name"
+                                        required
+                                        value={name}
+                                        onChange={(e) =>
+                                            setName(e.target.value)
+                                        }
+                                        placeholder="Methimazole"
+                                    />
+                                </div>
+                                <div className="grid grid-cols-2 gap-2">
+                                    <div className="space-y-1">
+                                        <Label htmlFor="med-dosage">
+                                            Dosage
+                                        </Label>
+                                        <Input
+                                            id="med-dosage"
+                                            value={dosage}
+                                            onChange={(e) =>
+                                                setDosage(e.target.value)
+                                            }
+                                            placeholder="2.5 mg"
+                                        />
+                                    </div>
+                                    <div className="space-y-1">
+                                        <Label htmlFor="med-freq">
+                                            Every (hours)
+                                        </Label>
+                                        <Input
+                                            id="med-freq"
+                                            type="number"
+                                            min="1"
+                                            max="1440"
+                                            required
+                                            value={frequencyHours}
+                                            onChange={(e) =>
+                                                setFrequencyHours(
+                                                    e.target.value,
+                                                )
+                                            }
+                                        />
+                                    </div>
+                                </div>
+                                <div className="grid grid-cols-2 gap-2">
+                                    <div className="space-y-1">
+                                        <Label htmlFor="med-starts">
+                                            Starts
+                                        </Label>
+                                        <Input
+                                            id="med-starts"
+                                            type="datetime-local"
+                                            value={startsAt}
+                                            onChange={(e) =>
+                                                setStartsAt(e.target.value)
+                                            }
+                                        />
+                                    </div>
+                                    <div className="space-y-1">
+                                        <Label htmlFor="med-ends">
+                                            Ends (optional)
+                                        </Label>
+                                        <Input
+                                            id="med-ends"
+                                            type="datetime-local"
+                                            value={endsAt}
+                                            onChange={(e) =>
+                                                setEndsAt(e.target.value)
+                                            }
+                                        />
+                                    </div>
+                                </div>
+                                <div className="space-y-1">
+                                    <Label htmlFor="med-notes">Notes</Label>
+                                    <Input
+                                        id="med-notes"
+                                        value={notes}
+                                        onChange={(e) =>
+                                            setNotes(e.target.value)
+                                        }
+                                        placeholder="With food"
+                                    />
+                                </div>
+                                {create.error && (
+                                    <p className="text-sm text-destructive">
+                                        {create.error.message}
+                                    </p>
+                                )}
+                                <DialogFooter>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={() => setOpen(false)}
+                                        disabled={create.isPending}
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button
+                                        type="submit"
+                                        disabled={create.isPending}
+                                    >
+                                        {create.isPending ? "Saving…" : "Save"}
+                                    </Button>
+                                </DialogFooter>
+                            </form>
+                        </DialogContent>
+                    </Dialog>
+                )}
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <p className="text-sm text-muted-foreground">Loading…</p>
+                ) : !data || data.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        No medications yet.
+                    </p>
+                ) : (
+                    <ul className="divide-y">
+                        {data.map((m) => {
+                            const due = isMedDue({
+                                startsAt: m.startsAt,
+                                endsAt: m.endsAt,
+                                lastGivenAt: m.lastGivenAt,
+                                frequencyHours: m.frequencyHours,
+                            });
+                            const next = nextDueAt({
+                                startsAt: m.startsAt,
+                                endsAt: m.endsAt,
+                                lastGivenAt: m.lastGivenAt,
+                                frequencyHours: m.frequencyHours,
+                            });
+                            return (
+                                <li
+                                    key={m.id}
+                                    className={cn(
+                                        "flex items-start justify-between gap-3 py-2 text-sm",
+                                        due && "bg-destructive/5",
+                                    )}
+                                >
+                                    <div className="min-w-0 flex-1">
+                                        <div className="flex items-center gap-2">
+                                            <span className="font-medium">
+                                                {m.name}
+                                            </span>
+                                            {due && (
+                                                <span className="rounded bg-destructive/15 px-1.5 py-0.5 text-[10px] uppercase text-destructive">
+                                                    Due
+                                                </span>
+                                            )}
+                                        </div>
+                                        <div className="text-xs text-muted-foreground">
+                                            {m.dosage ? `${m.dosage} · ` : ""}
+                                            every {m.frequencyHours}h
+                                            {next
+                                                ? ` · next ${next.toLocaleString()}`
+                                                : " · ended"}
+                                        </div>
+                                        {m.notes && (
+                                            <p className="mt-1 text-xs">
+                                                {m.notes}
+                                            </p>
+                                        )}
+                                    </div>
+                                    {canEdit && (
+                                        <div className="flex items-center gap-1">
+                                            <Button
+                                                type="button"
+                                                size="sm"
+                                                variant={due ? "default" : "outline"}
+                                                disabled={markGiven.isPending}
+                                                onClick={() =>
+                                                    markGiven.mutate({
+                                                        medId: m.id,
+                                                    })
+                                                }
+                                            >
+                                                <Check className="mr-1 h-3.5 w-3.5" />
+                                                Given
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                size="icon"
+                                                variant="ghost"
+                                                disabled={
+                                                    deleteEntry.isPending
+                                                }
+                                                onClick={() => {
+                                                    if (
+                                                        !confirm(
+                                                            `Remove ${m.name}?`,
+                                                        )
+                                                    )
+                                                        return;
+                                                    deleteEntry.mutate({
+                                                        medId: m.id,
+                                                    });
+                                                }}
+                                                aria-label="Remove med"
+                                                className="text-destructive hover:text-destructive"
+                                            >
+                                                <Trash2 className="h-3.5 w-3.5" />
+                                            </Button>
+                                        </div>
+                                    )}
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -10,6 +10,7 @@ import { WeightHistoryList } from "~/app/dashboard/pets/[id]/_components/weight-
 import { ExportCard } from "~/app/dashboard/pets/[id]/_components/export-card";
 import { FeedingHeatmapCard } from "~/app/dashboard/pets/[id]/_components/feeding-heatmap-card";
 import { HealthEventsCard } from "~/app/dashboard/pets/[id]/_components/health-events-card";
+import { MedsCard } from "~/app/dashboard/pets/[id]/_components/meds-card";
 import { NotesCard } from "~/app/dashboard/pets/[id]/_components/notes-card";
 import { ImportWeightCard } from "~/app/dashboard/pets/[id]/_components/import-weight-card";
 import { DeletePetCard } from "~/app/dashboard/pets/[id]/_components/delete-pet-card";
@@ -67,6 +68,7 @@ export default async function PetDetailPage({
             <FeedingHeatmapCard petId={pet.id} />
             <FeedingHistoryList petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <HealthEventsCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
+            <MedsCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <NotesCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <ImportWeightCard
                 petId={pet.id}

--- a/src/lib/meds-due.test.ts
+++ b/src/lib/meds-due.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { isMedDue, nextDueAt, type MedForDue } from "./meds-due";
+
+const now = new Date("2026-05-14T15:00:00Z");
+const hoursAgo = (h: number) => new Date(now.getTime() - h * 3_600_000);
+const hoursFromNow = (h: number) => new Date(now.getTime() + h * 3_600_000);
+
+describe("isMedDue", () => {
+    it("is not due before its start", () => {
+        const med: MedForDue = {
+            startsAt: hoursFromNow(2),
+            endsAt: null,
+            lastGivenAt: null,
+            frequencyHours: 12,
+        };
+        expect(isMedDue(med, now)).toBe(false);
+    });
+
+    it("is not due after its end", () => {
+        const med: MedForDue = {
+            startsAt: hoursAgo(72),
+            endsAt: hoursAgo(1),
+            lastGivenAt: hoursAgo(50),
+            frequencyHours: 12,
+        };
+        expect(isMedDue(med, now)).toBe(false);
+    });
+
+    it("is due when never given and started", () => {
+        const med: MedForDue = {
+            startsAt: hoursAgo(1),
+            endsAt: null,
+            lastGivenAt: null,
+            frequencyHours: 12,
+        };
+        expect(isMedDue(med, now)).toBe(true);
+    });
+
+    it("is due when last dose was longer than frequencyHours ago", () => {
+        const med: MedForDue = {
+            startsAt: hoursAgo(100),
+            endsAt: null,
+            lastGivenAt: hoursAgo(13),
+            frequencyHours: 12,
+        };
+        expect(isMedDue(med, now)).toBe(true);
+    });
+
+    it("is not due if the last dose was recent", () => {
+        const med: MedForDue = {
+            startsAt: hoursAgo(100),
+            endsAt: null,
+            lastGivenAt: hoursAgo(3),
+            frequencyHours: 12,
+        };
+        expect(isMedDue(med, now)).toBe(false);
+    });
+});
+
+describe("nextDueAt", () => {
+    it("returns null when ended", () => {
+        const med: MedForDue = {
+            startsAt: hoursAgo(72),
+            endsAt: hoursAgo(1),
+            lastGivenAt: hoursAgo(2),
+            frequencyHours: 12,
+        };
+        expect(nextDueAt(med, now)).toBeNull();
+    });
+
+    it("returns startsAt + interval when never given", () => {
+        const med: MedForDue = {
+            startsAt: hoursAgo(1),
+            endsAt: null,
+            lastGivenAt: null,
+            frequencyHours: 12,
+        };
+        const expected = new Date(
+            hoursAgo(1).getTime() + 12 * 3_600_000,
+        );
+        expect(nextDueAt(med, now)!.getTime()).toBe(expected.getTime());
+    });
+
+    it("returns lastGivenAt + interval when given before", () => {
+        const med: MedForDue = {
+            startsAt: hoursAgo(100),
+            endsAt: null,
+            lastGivenAt: hoursAgo(3),
+            frequencyHours: 12,
+        };
+        const expected = new Date(
+            hoursAgo(3).getTime() + 12 * 3_600_000,
+        );
+        expect(nextDueAt(med, now)!.getTime()).toBe(expected.getTime());
+    });
+});

--- a/src/lib/meds-due.ts
+++ b/src/lib/meds-due.ts
@@ -1,0 +1,34 @@
+export type MedForDue = {
+    startsAt: Date;
+    endsAt: Date | null;
+    lastGivenAt: Date | null;
+    frequencyHours: number;
+};
+
+/**
+ * Returns true if the med is currently due: it has started, hasn't ended,
+ * and either has never been given or enough time has passed since the
+ * last dose.
+ */
+export function isMedDue(med: MedForDue, now: Date = new Date()): boolean {
+    const t = now.getTime();
+    if (med.startsAt.getTime() > t) return false;
+    if (med.endsAt !== null && med.endsAt.getTime() < t) return false;
+    if (med.lastGivenAt === null) return true;
+    const gapHours = (t - med.lastGivenAt.getTime()) / 3_600_000;
+    return gapHours >= med.frequencyHours;
+}
+
+/**
+ * Returns the next due timestamp for the med, or null if it's ended.
+ */
+export function nextDueAt(
+    med: MedForDue,
+    now: Date = new Date(),
+): Date | null {
+    if (med.endsAt !== null && med.endsAt.getTime() < now.getTime()) {
+        return null;
+    }
+    const base = med.lastGivenAt ?? med.startsAt;
+    return new Date(base.getTime() + med.frequencyHours * 3_600_000);
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -5,6 +5,7 @@ import { feedingRouter } from "~/server/api/routers/feeding";
 import { foodRouter } from "~/server/api/routers/food";
 import { activityRouter } from "~/server/api/routers/activity";
 import { healthRouter } from "~/server/api/routers/health";
+import { medsRouter } from "~/server/api/routers/meds";
 import { notesRouter } from "~/server/api/routers/notes";
 
 /**
@@ -19,6 +20,7 @@ export const appRouter = createTRPCRouter({
   food: foodRouter,
   activity: activityRouter,
   health: healthRouter,
+  meds: medsRouter,
   notes: notesRouter,
 });
 

--- a/src/server/api/routers/meds.ts
+++ b/src/server/api/routers/meds.ts
@@ -1,0 +1,117 @@
+import { and, desc, eq, isNull } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { type db } from "~/server/db";
+import { petMeds } from "~/server/db/schema";
+import { assertPetAccess } from "~/server/api/petAccess";
+
+async function loadMedPetId(
+    database: typeof db,
+    medId: number,
+): Promise<number> {
+    const [row] = await database
+        .select({ petId: petMeds.petId })
+        .from(petMeds)
+        .where(eq(petMeds.id, medId))
+        .limit(1);
+    if (!row) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Med not found." });
+    }
+    return row.petId;
+}
+
+const createInput = z.object({
+    petId: z.number().int().positive(),
+    name: z.string().min(1).max(256),
+    dosage: z.string().max(128).optional(),
+    frequencyHours: z.number().int().positive().max(24 * 60),
+    startsAt: z.date(),
+    endsAt: z.date().optional(),
+    notes: z.string().max(1024).optional(),
+});
+
+export const medsRouter = createTRPCRouter({
+    list: protectedProcedure
+        .input(z.object({ petId: z.number().int().positive() }))
+        .query(async ({ ctx, input }) => {
+            await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            return ctx.db
+                .select()
+                .from(petMeds)
+                .where(
+                    and(
+                        eq(petMeds.petId, input.petId),
+                        isNull(petMeds.deletedAt),
+                    ),
+                )
+                .orderBy(desc(petMeds.startsAt));
+        }),
+
+    create: protectedProcedure
+        .input(createInput)
+        .mutation(async ({ ctx, input }) => {
+            const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot add meds.",
+                });
+            }
+            const [row] = await ctx.db
+                .insert(petMeds)
+                .values({
+                    petId: input.petId,
+                    name: input.name,
+                    dosage: input.dosage ?? null,
+                    frequencyHours: input.frequencyHours,
+                    startsAt: input.startsAt,
+                    endsAt: input.endsAt ?? null,
+                    notes: input.notes ?? null,
+                })
+                .returning();
+            if (!row) throw new Error("Failed to create med.");
+            return row;
+        }),
+
+    markGiven: protectedProcedure
+        .input(z.object({ medId: z.number().int().positive() }))
+        .mutation(async ({ ctx, input }) => {
+            const petId = await loadMedPetId(ctx.db, input.medId);
+            const role = await assertPetAccess(ctx.db, ctx.userId, petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot mark meds given.",
+                });
+            }
+            const now = new Date();
+            const [row] = await ctx.db
+                .update(petMeds)
+                .set({ lastGivenAt: now, updatedAt: now })
+                .where(eq(petMeds.id, input.medId))
+                .returning();
+            if (!row) throw new Error("Failed to mark med given.");
+            return row;
+        }),
+
+    deleteEntry: protectedProcedure
+        .input(z.object({ medId: z.number().int().positive() }))
+        .mutation(async ({ ctx, input }) => {
+            const petId = await loadMedPetId(ctx.db, input.medId);
+            const role = await assertPetAccess(ctx.db, ctx.userId, petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot delete meds.",
+                });
+            }
+            const now = new Date();
+            await ctx.db
+                .update(petMeds)
+                .set({ deletedAt: now, updatedAt: now })
+                .where(eq(petMeds.id, input.medId));
+            return { ok: true as const };
+        }),
+});

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -159,6 +159,28 @@ export const activityHistory = createTable(
     }),
 );
 
+export const petMeds = createTable(
+    "pet_meds",
+    {
+        id: serial("id").primaryKey(),
+        petId: integer("pet_id")
+            .references(() => pets.id)
+            .notNull(),
+        name: varchar("name", { length: 256 }).notNull(),
+        dosage: varchar("dosage", { length: 128 }),
+        frequencyHours: integer("frequency_hours").notNull(),
+        startsAt: timestamp("starts_at", { withTimezone: true }).notNull(),
+        endsAt: timestamp("ends_at", { withTimezone: true }),
+        lastGivenAt: timestamp("last_given_at", { withTimezone: true }),
+        notes: varchar("notes", { length: 1024 }),
+        deletedAt: timestamp("deleted_at", { withTimezone: true }),
+        ...timestamps,
+    },
+    (table) => ({
+        petIdx: index("pet_meds_pet_id_idx").on(table.petId),
+    }),
+);
+
 export const petNotes = createTable(
     "pet_notes",
     {


### PR DESCRIPTION
## Summary
S45. Recurring medication schedule with a "due now" indicator.

### Schema
- `pet_meds` (name, dosage, frequency_hours, starts_at, ends_at, last_given_at, notes, soft-delete) + index on `pet_id`. Additive migration `0009`

### API (`medsRouter`)
- `list(petId)` — active meds, latest-start first
- `create(petId, …)` — Owner/Editor
- `markGiven(medId)` — bumps `last_given_at`
- `deleteEntry(medId)` — soft delete

### Pure helpers
- `isMedDue` / `nextDueAt` in `~/lib/meds-due.ts`, both take an injectable `now`
- 8 new tests (58 total): before-start / after-end / never-given / due-since-last / not-due / next-due-first / next-due-subsequent / ended-null

### UI
- `MedsCard` on pet detail (between health events and notes). Title shows "N due" pill when any med is due. Per-row: "Due" badge + faint destructive background on due rows, next-due timestamp, "Given" button (primary when due, outline otherwise), trash for soft-delete

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_