### PR TITLE
S47: Upstash sliding-window rate limits on key mutations

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@trpc/client": "next",
     "@trpc/react-query": "next",
     "@trpc/server": "next",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "@vercel/blob": "^2.3.3",
     "@vercel/postgres": "^0.8.0",
     "@vercel/speed-insights": "^1.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,12 @@ importers:
       '@trpc/server':
         specifier: next
         version: 11.0.0-rc.403
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.38.0)
+      '@upstash/redis':
+        specifier: ^1.38.0
+        version: 1.38.0
       '@vercel/blob':
         specifier: ^2.3.3
         version: 2.3.3
@@ -1358,6 +1364,18 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.38.0':
+    resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
 
   '@vercel/blob@2.3.3':
     resolution: {integrity: sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==}
@@ -3481,6 +3499,9 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
@@ -4705,6 +4726,19 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.2.0': {}
+
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.38.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.38.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.38.0
+
+  '@upstash/redis@1.38.0':
+    dependencies:
+      uncrypto: 0.1.3
 
   '@vercel/blob@2.3.3':
     dependencies:
@@ -6951,6 +6985,8 @@ snapshots:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+
+  uncrypto@0.1.3: {}
 
   undici-types@5.26.5: {}
 

--- a/src/env.js
+++ b/src/env.js
@@ -16,6 +16,8 @@ export const env = createEnv({
     RESEND_API_KEY: z.string().optional(),
     RESEND_FROM: z.string().optional(),
     CRON_SECRET: z.string().optional(),
+    UPSTASH_REDIS_REST_URL: z.string().url().optional(),
+    UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
   },
 
   /**
@@ -39,6 +41,8 @@ export const env = createEnv({
     RESEND_API_KEY: process.env.RESEND_API_KEY,
     RESEND_FROM: process.env.RESEND_FROM,
     CRON_SECRET: process.env.CRON_SECRET,
+    UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+    UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
   },
   /**

--- a/src/server/api/ratelimit.ts
+++ b/src/server/api/ratelimit.ts
@@ -1,0 +1,57 @@
+import { Ratelimit, type Duration } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+import { TRPCError } from "@trpc/server";
+
+import { env } from "~/env";
+
+let redis: Redis | null | undefined = undefined;
+function getRedis(): Redis | null {
+    if (redis !== undefined) return redis;
+    if (!env.UPSTASH_REDIS_REST_URL || !env.UPSTASH_REDIS_REST_TOKEN) {
+        redis = null;
+        return null;
+    }
+    redis = new Redis({
+        url: env.UPSTASH_REDIS_REST_URL,
+        token: env.UPSTASH_REDIS_REST_TOKEN,
+    });
+    return redis;
+}
+
+const limiters = new Map<string, Ratelimit>();
+function getLimiter(name: string, limit: number, window: Duration) {
+    const cached = limiters.get(name);
+    if (cached) return cached;
+    const r = getRedis();
+    if (!r) return null;
+    const l = new Ratelimit({
+        redis: r,
+        limiter: Ratelimit.slidingWindow(limit, window),
+        analytics: false,
+        prefix: `mwt:${name}`,
+    });
+    limiters.set(name, l);
+    return l;
+}
+
+/**
+ * Throws TOO_MANY_REQUESTS when the caller has exceeded `limit` calls per
+ * `window`. No-ops when Upstash env vars aren't set, so local dev and
+ * environments without Redis still work.
+ */
+export async function enforceRateLimit(
+    name: string,
+    userId: string,
+    limit: number,
+    window: Duration,
+) {
+    const limiter = getLimiter(name, limit, window);
+    if (!limiter) return;
+    const { success } = await limiter.limit(userId);
+    if (!success) {
+        throw new TRPCError({
+            code: "TOO_MANY_REQUESTS",
+            message: `Rate limit exceeded for ${name}. Try again shortly.`,
+        });
+    }
+}

--- a/src/server/api/routers/feeding.ts
+++ b/src/server/api/routers/feeding.ts
@@ -9,6 +9,7 @@ import { recordFeedingInput } from "~/schema/recordFeedingInput";
 import { updateFeedingEntryInput } from "~/schema/updateFeedingEntryInput";
 import { deleteFeedingEntryInput } from "~/schema/deleteFeedingEntryInput";
 import { assertPetAccess } from "~/server/api/petAccess";
+import { enforceRateLimit } from "~/server/api/ratelimit";
 
 async function loadEntryPetId(
     database: typeof db,
@@ -32,6 +33,7 @@ export const feedingRouter = createTRPCRouter({
     recordFeeding: protectedProcedure
         .input(recordFeedingInput)
         .mutation(async ({ ctx, input }) => {
+            await enforceRateLimit("recordFeeding", ctx.userId, 60, "1 m");
             await assertPetAccess(ctx.db, ctx.userId, input.petId);
 
             const [entry] = await ctx.db

--- a/src/server/api/routers/pet.ts
+++ b/src/server/api/routers/pet.ts
@@ -10,6 +10,7 @@ import { getPetInput } from "~/schema/getPetInput";
 import { updatePetInput } from "~/schema/updatePetInput";
 import { petInvites, petPeople, pets, users } from "~/server/db/schema";
 import { assertPetAccess } from "~/server/api/petAccess";
+import { enforceRateLimit } from "~/server/api/ratelimit";
 
 const roleSchema = z.enum(["Owner", "Editor", "Viewer"]);
 
@@ -17,6 +18,7 @@ export const petRouter = createTRPCRouter({
     insertPet: protectedProcedure
         .input(createPetRequestInput)
         .mutation(async ({ ctx, input }) => {
+            await enforceRateLimit("insertPet", ctx.userId, 20, "1 h");
             return await ctx.db.transaction(async (trx) => {
                 const [newPet] = await trx
                     .insert(pets)
@@ -306,6 +308,7 @@ export const petRouter = createTRPCRouter({
             }),
         )
         .mutation(async ({ ctx, input }) => {
+            await enforceRateLimit("createInvite", ctx.userId, 10, "1 h");
             const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
             if (role !== "Owner") {
                 throw new TRPCError({

--- a/src/server/api/routers/weight.ts
+++ b/src/server/api/routers/weight.ts
@@ -14,6 +14,7 @@ import {
     updateWeightEntryInput,
 } from "~/schema/updateWeightEntryInput";
 import { assertPetAccess } from "~/server/api/petAccess";
+import { enforceRateLimit } from "~/server/api/ratelimit";
 
 async function loadEntryPetId(
     database: typeof db,
@@ -34,6 +35,7 @@ export const weightRouter = createTRPCRouter({
     recordWeight: protectedProcedure
         .input(recordWeightInput)
         .mutation(async ({ ctx, input }) => {
+            await enforceRateLimit("recordWeight", ctx.userId, 60, "1 m");
             await assertPetAccess(ctx.db, ctx.userId, input.petId);
 
             const [entry] = await ctx.db
@@ -125,6 +127,7 @@ export const weightRouter = createTRPCRouter({
             }),
         )
         .mutation(async ({ ctx, input }) => {
+            await enforceRateLimit("bulkImport", ctx.userId, 5, "1 h");
             const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
             if (role === "Viewer") {
                 throw new TRPCError({


### PR DESCRIPTION
## Summary
S47. Per-user sliding-window rate limits on the high-write mutations.

### Helper
`~/server/api/ratelimit.ts` constructs limiters lazily, caches them, and **no-ops when `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` aren't set**. Local dev and preview deploys still work without Redis.

### Limits (keyed by Clerk `userId`)
- `pet.createInvite` — 10 / hour (spam guard for the invite link feature)
- `pet.insertPet` — 20 / hour
- `weight.recordWeight` — 60 / minute
- `weight.bulkImport` — 5 / hour (CSV import is heavy)
- `feeding.recordFeeding` — 60 / minute

Exceeding the limit throws `TOO_MANY_REQUESTS`; the existing tRPC client error handler surfaces this as a toast.

### Env (both optional)
- `UPSTASH_REDIS_REST_URL`
- `UPSTASH_REDIS_REST_TOKEN`

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_