### PR TITLE
S48: router unit tests via stubbed db + createCaller

### DIFF
--- a/src/server/api/routers/__tests__/health-router.test.ts
+++ b/src/server/api/routers/__tests__/health-router.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { TRPCError } from "@trpc/server";
+
+import { createCaller } from "~/server/api/root";
+import { makeStubDb, type StubScenario } from "./mock-db";
+
+function callerWith(scenario: StubScenario, userId = "u_1") {
+    const db = makeStubDb(scenario);
+    return createCaller({ db, userId, headers: new Headers() });
+}
+
+describe("health router", () => {
+    it("record rejects Viewer role", async () => {
+        const caller = callerWith({
+            // assertPetAccess returns Viewer
+            selectRows: [[{ role: "Viewer" }]],
+        });
+        await expect(
+            caller.health.record({
+                petId: 7,
+                eventType: "Vet visit",
+                title: "Checkup",
+            }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("record succeeds for Editor", async () => {
+        const caller = callerWith({
+            selectRows: [[{ role: "Editor" }]],
+            insertRows: [{ id: 99, petId: 7, eventType: "Vet visit" }],
+        });
+        const result = await caller.health.record({
+            petId: 7,
+            eventType: "Vet visit",
+            title: "Checkup",
+        });
+        expect((result as { id: number }).id).toBe(99);
+    });
+
+    it("deleteEntry rejects Viewer", async () => {
+        const caller = callerWith({
+            // loadEntryPetId (returns petId), then assertPetAccess (returns role)
+            selectRows: [[{ petId: 7 }], [{ role: "Viewer" }]],
+        });
+        await expect(
+            caller.health.deleteEntry({ entryId: 42 }),
+        ).rejects.toBeInstanceOf(TRPCError);
+    });
+
+    it("deleteEntry NOT_FOUND when entry missing", async () => {
+        const caller = callerWith({
+            selectRows: [[]],
+        });
+        await expect(
+            caller.health.deleteEntry({ entryId: 9999 }),
+        ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    });
+});

--- a/src/server/api/routers/__tests__/mock-db.ts
+++ b/src/server/api/routers/__tests__/mock-db.ts
@@ -1,0 +1,74 @@
+import { type db as RealDb } from "~/server/db";
+
+/**
+ * Tiny stubbed db for router unit tests. Each call returns a thenable
+ * chain that resolves to the rows passed in the scenario for whichever
+ * query shape the router uses next.
+ *
+ * `selectRows` is a FIFO queue, so multi-step routers (loadEntryPetId
+ * then assertPetAccess) get rows in the order the code asks for them.
+ */
+export type StubScenario = {
+    selectRows?: unknown[][];
+    insertRows?: unknown[];
+    updateRows?: unknown[];
+};
+
+export type StubDb = typeof RealDb;
+
+export function makeStubDb(scenario: StubScenario) {
+    const selectQueue = [...(scenario.selectRows ?? [])];
+
+    function selectChain() {
+        const chain = {
+            from: () => chain,
+            innerJoin: () => chain,
+            where: () => chain,
+            orderBy: () => chain,
+            limit: () => {
+                const next = selectQueue.shift() ?? [];
+                return Promise.resolve(next);
+            },
+            then: (
+                onFulfilled?: (rows: unknown[]) => unknown,
+                onRejected?: (reason: unknown) => unknown,
+            ) => {
+                const next = selectQueue.shift() ?? [];
+                return Promise.resolve(next).then(onFulfilled, onRejected);
+            },
+        };
+        return chain;
+    }
+
+    return {
+        select: () => selectChain(),
+        insert: () => ({
+            values: () => ({
+                returning: () =>
+                    Promise.resolve(scenario.insertRows ?? [{ id: 1 }]),
+                onConflictDoNothing: () => Promise.resolve(undefined),
+            }),
+        }),
+        update: () => ({
+            set: () => ({
+                where: () => ({
+                    returning: () =>
+                        Promise.resolve(scenario.updateRows ?? [{ id: 1 }]),
+                    then: (
+                        onFulfilled?: (v: unknown) => unknown,
+                        onRejected?: (reason: unknown) => unknown,
+                    ) =>
+                        Promise.resolve(undefined).then(
+                            onFulfilled,
+                            onRejected,
+                        ),
+                }),
+            }),
+        }),
+        delete: () => ({
+            where: () => Promise.resolve(undefined),
+        }),
+        transaction: async (cb: (trx: unknown) => Promise<unknown>) =>
+            cb(makeStubDb(scenario)),
+    } as unknown as StubDb;
+}

--- a/src/server/api/routers/__tests__/notes-router.test.ts
+++ b/src/server/api/routers/__tests__/notes-router.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { createCaller } from "~/server/api/root";
+import { makeStubDb, type StubScenario } from "./mock-db";
+
+function callerWith(scenario: StubScenario, userId = "u_1") {
+    const db = makeStubDb(scenario);
+    return createCaller({ db, userId, headers: new Headers() });
+}
+
+describe("notes router", () => {
+    it("record rejects Viewer", async () => {
+        const caller = callerWith({
+            selectRows: [[{ role: "Viewer" }]],
+        });
+        await expect(
+            caller.notes.record({ petId: 1, body: "hi" }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("record succeeds for Owner", async () => {
+        const caller = callerWith({
+            selectRows: [[{ role: "Owner" }]],
+            insertRows: [{ id: 5, petId: 1, body: "hi" }],
+        });
+        const out = await caller.notes.record({ petId: 1, body: "hi" });
+        expect((out as { id: number }).id).toBe(5);
+    });
+
+    it("getNotes resolves for Viewer (read-only)", async () => {
+        const caller = callerWith({
+            // assertPetAccess returns Viewer, then the SELECT returns []
+            selectRows: [[{ role: "Viewer" }], []],
+        });
+        const rows = await caller.notes.getNotes({ petId: 1 });
+        expect(rows).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
S48. Integration-style tests for tRPC routers via a hand-rolled db stub + the real `createCaller`.

### Stub
- `mock-db.ts` satisfies just enough of the Drizzle chain shapes the routers actually use:
  - `select(...).from(...).innerJoin(...).where(...).orderBy(...).limit(...)` + `then`
  - `insert(...).values(...).returning()` + `onConflictDoNothing()`
  - `update(...).set(...).where(...).returning?()`
  - `delete(...).where(...)`
  - `transaction(cb)`
- `selectRows` is a FIFO queue, so multi-step routers (e.g. `loadEntryPetId` then `assertPetAccess`) get the right rows in order

### Tests (7 new, 65 total)
- `health.record` — Viewer rejected; Editor succeeds (returns new row)
- `health.deleteEntry` — Viewer rejected; NOT_FOUND on missing entry
- `notes.record` — Viewer rejected; Owner succeeds
- `notes.getNotes` — Viewer can read

### Pattern
Calls go through `createCaller` with a stubbed `db`/`userId`/`headers` context, so the real `protectedProcedure` middleware, Zod validation, and router code execute. Same pattern extends to `activity`, `food`, `meds`, and the `pet` mutations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_