### PR TITLE
S49: wire Playwright E2E into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,17 @@ jobs:
 
       - name: Next.js build
         run: pnpm build
+
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: E2E smoke (Playwright)
+        run: pnpm test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,12 @@
 import { defineConfig, devices } from "@playwright/test";
 
 /**
- * Minimal Playwright config. Runs against an already-running dev server at
- * PLAYWRIGHT_BASE_URL (default http://localhost:3000). Doesn't spawn the
- * server itself — keeps the test runtime fast and avoids fighting Next.js
- * over ports during CI in the future.
+ * Locally: reuses an already-running dev server at PLAYWRIGHT_BASE_URL
+ * (default http://localhost:3000). In CI: spins up `pnpm start` against
+ * the build output and waits for it before running tests.
  */
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+
 export default defineConfig({
     testDir: "./tests/e2e",
     fullyParallel: true,
@@ -14,7 +15,7 @@ export default defineConfig({
     workers: process.env.CI ? 1 : undefined,
     reporter: process.env.CI ? "line" : "list",
     use: {
-        baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
+        baseURL,
         trace: "on-first-retry",
     },
     projects: [
@@ -23,4 +24,14 @@ export default defineConfig({
             use: { ...devices["Desktop Chrome"] },
         },
     ],
+    webServer: process.env.PLAYWRIGHT_NO_SERVER
+        ? undefined
+        : {
+              command: "pnpm start",
+              url: baseURL,
+              reuseExistingServer: !process.env.CI,
+              timeout: 120_000,
+              stdout: "pipe",
+              stderr: "pipe",
+          },
 });


### PR DESCRIPTION
## Summary
S49. Playwright runs against the built app in CI.

### Changes
- `playwright.config.ts` now declares a `webServer` block: `pnpm start`, waits for `baseURL` up to 120s. `reuseExistingServer: !CI`, so locally it reuses an existing dev server while CI spins up its own
- `PLAYWRIGHT_NO_SERVER` escape hatch for environments with their own server
- CI workflow: install Chromium via `playwright install --with-deps chromium`, run `pnpm test:e2e` after the build step, and upload `playwright-report` as an artifact on failure (7-day retention)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_