### PR TITLE
S51: code-split Recharts via next/dynamic

### DIFF
--- a/src/app/dashboard/_components/dashboard-content.tsx
+++ b/src/app/dashboard/_components/dashboard-content.tsx
@@ -5,8 +5,12 @@ import { useState } from "react";
 import { ChevronRight } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
-import { FoodBreakdownChart } from "~/app/dashboard/_components/food-breakdown-chart";
-import { KcalTrendChart } from "~/app/dashboard/_components/kcal-trend-chart";
+import {
+    FoodBreakdownChart,
+    KcalTrendChart,
+    WeightChart,
+    WeightStatsCard,
+} from "~/app/dashboard/_components/lazy-charts";
 import { PetAlerts } from "~/app/dashboard/_components/pet-alerts";
 import { PetPicker } from "~/app/dashboard/_components/pet-picker";
 import { RecordActivityDialog } from "~/app/dashboard/_components/record-activity-dialog";
@@ -14,8 +18,6 @@ import { RecordFeedingDialog } from "~/app/dashboard/_components/record-feeding-
 import { RecordWeightDialog } from "~/app/dashboard/_components/record-weight-dialog";
 import { TodayActivity } from "~/app/dashboard/_components/today-activity";
 import { TodayFeedings } from "~/app/dashboard/_components/today-feedings";
-import { WeightChart } from "~/app/dashboard/_components/weight-chart";
-import { WeightStatsCard } from "~/app/dashboard/_components/weight-stats-card";
 import { type RouterOutputs } from "~/trpc/react";
 
 type Pet = RouterOutputs["pet"]["getPets"][number];

--- a/src/app/dashboard/_components/lazy-charts.tsx
+++ b/src/app/dashboard/_components/lazy-charts.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import { Skeleton } from "~/components/ui/skeleton";
+
+/**
+ * Recharts ships a big bundle (~140kB gzipped) and we never need it on the
+ * server, so dynamic-import each chart with ssr: false. The skeleton
+ * keeps the layout stable while the chunk lands.
+ */
+
+export const WeightChart = dynamic(
+    () =>
+        import("./weight-chart").then((m) => ({
+            default: m.WeightChart,
+        })),
+    { ssr: false, loading: () => <Skeleton className="h-72 w-full" /> },
+);
+
+export const KcalTrendChart = dynamic(
+    () =>
+        import("./kcal-trend-chart").then((m) => ({
+            default: m.KcalTrendChart,
+        })),
+    { ssr: false, loading: () => <Skeleton className="h-56 w-full" /> },
+);
+
+export const FoodBreakdownChart = dynamic(
+    () =>
+        import("./food-breakdown-chart").then((m) => ({
+            default: m.FoodBreakdownChart,
+        })),
+    { ssr: false, loading: () => <Skeleton className="h-64 w-full" /> },
+);
+
+export const WeightStatsCard = dynamic(
+    () =>
+        import("./weight-stats-card").then((m) => ({
+            default: m.WeightStatsCard,
+        })),
+    { ssr: false, loading: () => <Skeleton className="h-32 w-full" /> },
+);

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -15,8 +15,10 @@ import { NotesCard } from "~/app/dashboard/pets/[id]/_components/notes-card";
 import { ImportWeightCard } from "~/app/dashboard/pets/[id]/_components/import-weight-card";
 import { DeletePetCard } from "~/app/dashboard/pets/[id]/_components/delete-pet-card";
 import { PetAlerts } from "~/app/dashboard/_components/pet-alerts";
-import { WeightChart } from "~/app/dashboard/_components/weight-chart";
-import { WeightStatsCard } from "~/app/dashboard/_components/weight-stats-card";
+import {
+    WeightChart,
+    WeightStatsCard,
+} from "~/app/dashboard/_components/lazy-charts";
 import { api } from "~/trpc/server";
 
 export default async function PetDetailPage({


### PR DESCRIPTION
## Summary
S51. Pull Recharts off the critical path with `next/dynamic`.

### Changes
- New `~/app/dashboard/_components/lazy-charts.tsx` re-exports the four Recharts-using cards (`WeightChart`, `KcalTrendChart`, `FoodBreakdownChart`, `WeightStatsCard`) wrapped in `next/dynamic` with `ssr: false`
- Each gets a correctly-sized `Skeleton` fallback so layout stays stable while the chunk loads
- Imports at use sites swapped over; no API changes

### Why
Recharts ships ~140KB gzipped and isn't needed on the server. Dashboard and pet-detail pages now load without it on the critical path; charts hydrate after first paint.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_