### PR TITLE
fix: externalize @vercel/blob to unbreak Next 14 build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,12 @@
 await import("./src/env.js");
 
 /** @type {import("next").NextConfig} */
-const config = {};
+const config = {
+  // @vercel/blob v2 bundles undici, which ships private-class-field syntax that
+  // Next 14's webpack loader can't parse. Keep it as a runtime Node import.
+  experimental: {
+    serverComponentsExternalPackages: ["@vercel/blob"],
+  },
+};
 
 export default config;


### PR DESCRIPTION
## Summary
- `main` build is broken: `@vercel/blob` v2 bundles `undici@6.25.0`, whose private-class-field syntax (`#target`) the Next 14.2.4 webpack loader can't parse. This fails the `Next.js build` CI step (and prod build) via `src/app/api/pets/[id]/photo/route.ts`.
- Fix: add `experimental.serverComponentsExternalPackages: ["@vercel/blob"]` so it stays a runtime Node import instead of being bundled.

## Test plan
- [x] `pnpm build` succeeds locally
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 65/65 pass
- [ ] Vercel preview will still fail — account-level build rate limit, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)