### PR TITLE
S54: weight input in the chosen unit

### DIFF
--- a/src/app/_components/bottom-nav.tsx
+++ b/src/app/_components/bottom-nav.tsx
@@ -2,12 +2,17 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Cat, Plus, Utensils } from "lucide-react";
+import { Cat, Plus, Settings, Utensils } from "lucide-react";
 
 import { cn } from "~/lib/utils";
 
 const TABS = [
-    { href: "/dashboard", label: "Pets", icon: Cat, match: /^\/dashboard(?!\/foods)/ },
+    {
+        href: "/dashboard",
+        label: "Pets",
+        icon: Cat,
+        match: /^\/dashboard(?!\/foods|\/settings)/,
+    },
     {
         href: "/dashboard/pets/new",
         label: "Add",
@@ -20,6 +25,12 @@ const TABS = [
         icon: Utensils,
         match: /^\/dashboard\/foods/,
     },
+    {
+        href: "/dashboard/settings",
+        label: "Settings",
+        icon: Settings,
+        match: /^\/dashboard\/settings/,
+    },
 ] as const;
 
 export function BottomNav() {
@@ -29,7 +40,7 @@ export function BottomNav() {
             aria-label="Primary"
             className="fixed inset-x-0 bottom-0 z-40 border-t bg-background pb-[env(safe-area-inset-bottom)] md:hidden"
         >
-            <ul className="mx-auto grid max-w-md grid-cols-3">
+            <ul className="mx-auto grid max-w-md grid-cols-4">
                 {TABS.map((tab) => {
                     const Icon = tab.icon;
                     const active = tab.match.test(pathname);

--- a/src/app/_components/topnav.tsx
+++ b/src/app/_components/topnav.tsx
@@ -29,6 +29,12 @@ export function TopNav() {
                     >
                         Deleted
                     </Link>
+                    <Link
+                        href="/dashboard/settings"
+                        className="hidden text-sm text-muted-foreground hover:text-foreground md:inline"
+                    >
+                        Settings
+                    </Link>
                     <ThemeToggle />
                     <UserButton afterSignOutUrl="/" />
                 </SignedIn>

--- a/src/app/api/account/export/route.ts
+++ b/src/app/api/account/export/route.ts
@@ -1,0 +1,126 @@
+import { auth } from "@clerk/nextjs/server";
+import { eq, inArray } from "drizzle-orm";
+
+import { db } from "~/server/db";
+import {
+    activityHistory,
+    eatingHistory,
+    healthEvents,
+    petFood,
+    petMeds,
+    petNotes,
+    petPeople,
+    pets,
+    userPreferences,
+    weightHistory,
+} from "~/server/db/schema";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Full account data export: every pet the caller can see (with their
+ * role) and all of its history, plus the caller's preferences. Returned
+ * as a downloadable JSON file. Dates serialize to ISO via Date#toJSON.
+ */
+export async function GET() {
+    const { userId } = auth();
+    if (!userId) return new Response("Unauthorized", { status: 401 });
+
+    const memberships = await db
+        .select({ petId: petPeople.petId, role: petPeople.role })
+        .from(petPeople)
+        .where(eq(petPeople.userId, userId));
+    const petIds = memberships.map((m) => m.petId);
+    const roleByPet = new Map(memberships.map((m) => [m.petId, m.role]));
+
+    const empty: never[] = [];
+    const [
+        petRows,
+        weights,
+        feedings,
+        activities,
+        health,
+        notes,
+        meds,
+        prefsRows,
+    ] = await Promise.all([
+        petIds.length
+            ? db.select().from(pets).where(inArray(pets.id, petIds))
+            : empty,
+        petIds.length
+            ? db
+                  .select()
+                  .from(weightHistory)
+                  .where(inArray(weightHistory.petId, petIds))
+            : empty,
+        petIds.length
+            ? db
+                  .select({
+                      id: eatingHistory.id,
+                      petId: eatingHistory.petId,
+                      fedAt: eatingHistory.fedAt,
+                      quantityGrams: eatingHistory.quantityGrams,
+                      foodName: petFood.name,
+                      foodBrand: petFood.brand,
+                      caloriesPerGram: petFood.caloriesPerGram,
+                      createdAt: eatingHistory.createdAt,
+                  })
+                  .from(eatingHistory)
+                  .innerJoin(petFood, eq(eatingHistory.foodId, petFood.id))
+                  .where(inArray(eatingHistory.petId, petIds))
+            : empty,
+        petIds.length
+            ? db
+                  .select()
+                  .from(activityHistory)
+                  .where(inArray(activityHistory.petId, petIds))
+            : empty,
+        petIds.length
+            ? db
+                  .select()
+                  .from(healthEvents)
+                  .where(inArray(healthEvents.petId, petIds))
+            : empty,
+        petIds.length
+            ? db
+                  .select()
+                  .from(petNotes)
+                  .where(inArray(petNotes.petId, petIds))
+            : empty,
+        petIds.length
+            ? db.select().from(petMeds).where(inArray(petMeds.petId, petIds))
+            : empty,
+        db
+            .select()
+            .from(userPreferences)
+            .where(eq(userPreferences.userId, userId)),
+    ]);
+
+    const byPet = <T extends { petId: number }>(rows: T[], id: number) =>
+        rows.filter((r) => r.petId === id);
+
+    const payload = {
+        exportedAt: new Date().toISOString(),
+        userId,
+        preferences: prefsRows[0] ?? null,
+        pets: petRows.map((pet) => ({
+            ...pet,
+            role: roleByPet.get(pet.id) ?? null,
+            weights: byPet(weights, pet.id),
+            feedings: byPet(feedings, pet.id),
+            activities: byPet(activities, pet.id),
+            healthEvents: byPet(health, pet.id),
+            notes: byPet(notes, pet.id),
+            meds: byPet(meds, pet.id),
+        })),
+    };
+
+    const filename = `meow-export-${new Date().toISOString().slice(0, 10)}.json`;
+    return new Response(JSON.stringify(payload, null, 2), {
+        status: 200,
+        headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            "Content-Disposition": `attachment; filename="${filename}"`,
+        },
+    });
+}

--- a/src/app/api/cron/daily-reminders/route.ts
+++ b/src/app/api/cron/daily-reminders/route.ts
@@ -8,6 +8,7 @@ import {
     eatingHistory,
     petPeople,
     pets,
+    userPreferences,
 } from "~/server/db/schema";
 
 export const dynamic = "force-dynamic";
@@ -76,6 +77,14 @@ export async function GET(req: Request) {
     const now = Date.now();
     const cutoff = new Date(now - HUNGRY_HOURS * 3_600_000);
 
+    // Users who explicitly turned reminders off. A missing preferences row
+    // means the default (enabled), so we only need the opt-out set.
+    const optedOutRows = await db
+        .select({ userId: userPreferences.userId })
+        .from(userPreferences)
+        .where(eq(userPreferences.dailyRemindersEnabled, false));
+    const optedOut = new Set(optedOutRows.map((r) => r.userId));
+
     const allPets = await db
         .select({ id: pets.id, name: pets.name })
         .from(pets)
@@ -100,9 +109,19 @@ export async function GET(req: Request) {
         const hours = Math.floor(
             (now - lastFeeding.fedAt.getTime()) / 3_600_000,
         );
-        const recipients = await recipientsForPet(pet.id);
+        const allRecipients = await recipientsForPet(pet.id);
+        const recipients = allRecipients.filter(
+            (r) => !optedOut.has(r.userId),
+        );
         if (recipients.length === 0) {
-            summary.push({ petId: pet.id, sent: 0, reason: "no-recipients" });
+            summary.push({
+                petId: pet.id,
+                sent: 0,
+                reason:
+                    allRecipients.length > 0
+                        ? "all-opted-out"
+                        : "no-recipients",
+            });
             continue;
         }
         const subject = `${pet.name} hasn't been fed in ${hours}h`;

--- a/src/app/dashboard/_components/dashboard-content.tsx
+++ b/src/app/dashboard/_components/dashboard-content.tsx
@@ -28,6 +28,7 @@ export function DashboardContent({ pets }: { pets: Pet[] }) {
 
     return (
         <div className="space-y-6">
+            <h1 className="sr-only">Pet dashboard</h1>
             <PetAlerts petId={selectedPet.id} petName={selectedPet.name} />
             <PetPicker
                 pets={pets}

--- a/src/app/dashboard/_components/food-breakdown-chart.tsx
+++ b/src/app/dashboard/_components/food-breakdown-chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { Utensils } from "lucide-react";
 import {
     Bar,
     BarChart,
@@ -19,6 +20,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Skeleton } from "~/components/ui/skeleton";
 import { computeFoodBreakdown } from "~/lib/food-breakdown";
 import { api } from "~/trpc/react";
@@ -60,13 +62,22 @@ export function FoodBreakdownChart({
                 {isLoading ? (
                     <Skeleton className="h-56 w-full" />
                 ) : series.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No feedings in the last 30 days.
-                    </p>
+                    <EmptyState
+                        icon={Utensils}
+                        title="No feedings in the last 30 days"
+                        description="Log some meals to see where the calories come from."
+                    />
                 ) : (
-                    <div className="h-56 w-full">
+                    <div
+                        className="h-56 w-full"
+                        role="img"
+                        aria-label={`${petName}'s calorie sources over the last 30 days, stacked by day across ${series.length} ${
+                            series.length === 1 ? "food" : "foods"
+                        }.`}
+                    >
                         <ResponsiveContainer width="100%" height="100%">
                             <BarChart
+                                accessibilityLayer
                                 data={chartData}
                                 margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
                             >

--- a/src/app/dashboard/_components/kcal-trend-chart.tsx
+++ b/src/app/dashboard/_components/kcal-trend-chart.tsx
@@ -56,9 +56,18 @@ export function KcalTrendChart({
                 {isLoading ? (
                     <Skeleton className="h-48 w-full" />
                 ) : (
-                    <div className="h-48 w-full">
+                    <div
+                        className="h-48 w-full"
+                        role="img"
+                        aria-label={`Daily calorie intake for ${petName} over the last ${days.length} days${
+                            dailyKcalTarget
+                                ? `, against a target of ${dailyKcalTarget} kcal`
+                                : ""
+                        }.`}
+                    >
                         <ResponsiveContainer width="100%" height="100%">
                             <BarChart
+                                accessibilityLayer
                                 data={days}
                                 margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
                             >

--- a/src/app/dashboard/_components/onboarding-welcome.tsx
+++ b/src/app/dashboard/_components/onboarding-welcome.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import { Activity, ArrowRight, Scale, Users, Utensils } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+
+const HIGHLIGHTS = [
+    {
+        icon: Scale,
+        title: "Track weight",
+        body: "Log readings and watch the trend toward a goal weight.",
+    },
+    {
+        icon: Utensils,
+        title: "Log feedings",
+        body: "Record meals and keep an eye on daily calories.",
+    },
+    {
+        icon: Activity,
+        title: "Note activity & health",
+        body: "Walks, play, vet visits, meds — all in one place.",
+    },
+    {
+        icon: Users,
+        title: "Share with family",
+        body: "Invite others to help track a pet you care for together.",
+    },
+] as const;
+
+/**
+ * First-run experience shown on the dashboard when the account has no
+ * pets yet. Orients the user and funnels them into the add-pet form.
+ */
+export function OnboardingWelcome() {
+    return (
+        <div className="mx-auto max-w-2xl space-y-6">
+            <div className="space-y-2 text-center">
+                <div className="text-4xl">🐾</div>
+                <h1 className="text-2xl font-semibold">Welcome to Meow</h1>
+                <p className="text-muted-foreground">
+                    Keep your pet&apos;s weight, meals, and health in one
+                    simple place. Start by adding your first pet.
+                </p>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+                {HIGHLIGHTS.map((h) => {
+                    const Icon = h.icon;
+                    return (
+                        <Card key={h.title}>
+                            <CardHeader className="pb-2">
+                                <CardTitle className="flex items-center gap-2 text-base">
+                                    <Icon className="h-4 w-4 text-primary" />
+                                    {h.title}
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <CardDescription>{h.body}</CardDescription>
+                            </CardContent>
+                        </Card>
+                    );
+                })}
+            </div>
+
+            <div className="flex flex-col items-center gap-2">
+                <Button asChild size="lg">
+                    <Link href="/dashboard/pets/new">
+                        Add your first pet
+                        <ArrowRight className="ml-2 h-4 w-4" />
+                    </Link>
+                </Button>
+                <p className="text-xs text-muted-foreground">
+                    Takes about a minute. You can edit everything later.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/src/app/dashboard/_components/record-weight-dialog.tsx
+++ b/src/app/dashboard/_components/record-weight-dialog.tsx
@@ -22,12 +22,15 @@ import {
 } from "~/components/ui/dialog";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
+import { useWeightUnit } from "~/hooks/use-weight-unit";
+import { toKg } from "~/lib/units";
 import { api } from "~/trpc/react";
 import { type RouterOutputs } from "~/trpc/react";
 
 type Pet = RouterOutputs["pet"]["getPets"][number];
 
 export function RecordWeightDialog({ pet }: { pet: Pet }) {
+    const unit = useWeightUnit();
     const [open, setOpen] = useState(false);
     const [weight, setWeight] = useState("");
     const [recordedAt, setRecordedAt] = useState("");
@@ -87,7 +90,8 @@ export function RecordWeightDialog({ pet }: { pet: Pet }) {
         if (!Number.isFinite(numeric) || numeric <= 0) return;
         recordWeight.mutate({
             petId: pet.id,
-            weight: numeric,
+            // Stored canonically as kg; the form collects the chosen unit.
+            weight: toKg(numeric, unit),
             ...(recordedAt ? { recordedAt: new Date(recordedAt) } : {}),
         });
     }
@@ -117,7 +121,7 @@ export function RecordWeightDialog({ pet }: { pet: Pet }) {
                     </DialogHeader>
 
                     <div className="space-y-2">
-                        <Label htmlFor="weight">Weight</Label>
+                        <Label htmlFor="weight">Weight ({unit})</Label>
                         <Input
                             id="weight"
                             type="number"
@@ -128,7 +132,7 @@ export function RecordWeightDialog({ pet }: { pet: Pet }) {
                             autoFocus
                             value={weight}
                             onChange={(e) => setWeight(e.target.value)}
-                            placeholder="5.4"
+                            placeholder={unit === "lb" ? "11.9" : "5.4"}
                         />
                     </div>
 

--- a/src/app/dashboard/_components/today-activity.tsx
+++ b/src/app/dashboard/_components/today-activity.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { Trash2 } from "lucide-react";
+import { Activity, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
@@ -12,6 +12,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Skeleton } from "~/components/ui/skeleton";
 import { api } from "~/trpc/react";
 
@@ -70,9 +71,11 @@ export function TodayActivity({
                         <Skeleton className="h-12 w-full" />
                     </div>
                 ) : today.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No activity logged today yet.
-                    </p>
+                    <EmptyState
+                        icon={Activity}
+                        title="Nothing logged today"
+                        description="Record a walk or play session to track it here."
+                    />
                 ) : (
                     <ul className="space-y-2">
                         {today.map((row) => (

--- a/src/app/dashboard/_components/today-feedings.tsx
+++ b/src/app/dashboard/_components/today-feedings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { Utensils } from "lucide-react";
 
 import {
     Card,
@@ -10,6 +11,7 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { FeedingRowActions } from "~/app/dashboard/_components/feeding-row-actions";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Skeleton } from "~/components/ui/skeleton";
 import { cn } from "~/lib/utils";
 import { api } from "~/trpc/react";
@@ -94,9 +96,11 @@ export function TodayFeedings({
                         <Skeleton className="h-12 w-full" />
                     </div>
                 ) : today.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No feedings logged today yet.
-                    </p>
+                    <EmptyState
+                        icon={Utensils}
+                        title="No feedings logged today"
+                        description="Log a meal to start tracking today's calories."
+                    />
                 ) : (
                     <ul className="space-y-2">
                         {today.map((row) => {

--- a/src/app/dashboard/_components/weight-chart.tsx
+++ b/src/app/dashboard/_components/weight-chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { Scale } from "lucide-react";
 import {
     CartesianGrid,
     Line,
@@ -21,6 +22,7 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { Skeleton } from "~/components/ui/skeleton";
+import { EmptyState } from "~/components/ui/empty-state";
 import { useWeightUnit } from "~/hooks/use-weight-unit";
 import { formatWeight, fromKg } from "~/lib/units";
 import { cn } from "~/lib/utils";
@@ -120,9 +122,12 @@ export function WeightChart({
                 {isLoading ? (
                     <Skeleton className="h-64 w-full" />
                 ) : points.length === 0 ? (
-                    <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
-                        No weight readings in this range yet.
-                    </div>
+                    <EmptyState
+                        icon={Scale}
+                        title="No readings in this range"
+                        description="Try a wider range, or log a weight to get started."
+                        className="h-64"
+                    />
                 ) : (
                     <div className="h-64 w-full">
                         <ResponsiveContainer width="100%" height="100%">

--- a/src/app/dashboard/_components/weight-chart.tsx
+++ b/src/app/dashboard/_components/weight-chart.tsx
@@ -129,9 +129,16 @@ export function WeightChart({
                         className="h-64"
                     />
                 ) : (
-                    <div className="h-64 w-full">
+                    <div
+                        className="h-64 w-full"
+                        role="img"
+                        aria-label={`${petName}'s weight chart — ${points.length} ${
+                            points.length === 1 ? "reading" : "readings"
+                        } in the selected range, measured in ${unit}.`}
+                    >
                         <ResponsiveContainer width="100%" height="100%">
                             <LineChart
+                                accessibilityLayer
                                 data={points}
                                 margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
                             >

--- a/src/app/dashboard/_components/weight-stats-card.tsx
+++ b/src/app/dashboard/_components/weight-stats-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { ArrowDown, ArrowRight, ArrowUp } from "lucide-react";
+import { ArrowDown, ArrowRight, ArrowUp, LineChart } from "lucide-react";
 
 import {
     Card,
@@ -10,6 +10,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Skeleton } from "~/components/ui/skeleton";
 import { useWeightUnit } from "~/hooks/use-weight-unit";
 import { formatWeight, fromKg, type WeightUnit } from "~/lib/units";
@@ -49,9 +50,11 @@ export function WeightStatsCard({
                         <Skeleton className="h-12" />
                     </div>
                 ) : !stats ? (
-                    <p className="text-sm text-muted-foreground">
-                        Log at least two weights to see a trend.
-                    </p>
+                    <EmptyState
+                        icon={LineChart}
+                        title="Not enough data yet"
+                        description="Log at least two weight readings and the trend will show up here."
+                    />
                 ) : (
                     <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
                         <Stat

--- a/src/app/dashboard/foods/_components/add-food-form.tsx
+++ b/src/app/dashboard/foods/_components/add-food-form.tsx
@@ -83,7 +83,7 @@ export function AddFoodForm() {
                     placeholder="3.65"
                 />
             </div>
-            <div className="grid grid-cols-3 gap-2">
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
                 <MacroField id="food-p" label="Protein %" value={protein} onChange={setProtein} />
                 <MacroField id="food-f" label="Fat %" value={fat} onChange={setFat} />
                 <MacroField id="food-c" label="Carbs %" value={carbs} onChange={setCarbs} />

--- a/src/app/dashboard/foods/_components/food-list.tsx
+++ b/src/app/dashboard/foods/_components/food-list.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { Utensils } from "lucide-react";
+
 import { Card, CardContent } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { api } from "~/trpc/react";
 
 export function FoodList() {
@@ -12,8 +15,12 @@ export function FoodList() {
     if (!data || data.length === 0) {
         return (
             <Card>
-                <CardContent className="p-6 text-sm text-muted-foreground">
-                    No foods yet. Add the first one on the right.
+                <CardContent className="p-2">
+                    <EmptyState
+                        icon={Utensils}
+                        title="No foods yet"
+                        description="Add your first food using the form to get started."
+                    />
                 </CardContent>
             </Card>
         );

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -8,8 +8,17 @@ export default function DashboardLayout({
 }) {
     return (
         <div className="min-h-screen bg-background">
+            <a
+                href="#main-content"
+                className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:shadow-md focus:ring-2 focus:ring-ring"
+            >
+                Skip to content
+            </a>
             <TopNav />
-            <main className="container mx-auto py-6 pb-24 md:py-8 md:pb-8">
+            <main
+                id="main-content"
+                className="container mx-auto py-6 pb-24 md:py-8 md:pb-8"
+            >
                 {children}
             </main>
             <BottomNav />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,37 +1,12 @@
-import Link from "next/link";
-
-import { Button } from "~/components/ui/button";
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from "~/components/ui/card";
 import { DashboardContent } from "~/app/dashboard/_components/dashboard-content";
+import { OnboardingWelcome } from "~/app/dashboard/_components/onboarding-welcome";
 import { api } from "~/trpc/server";
 
 export default async function DashboardPage() {
     const pets = await api.pet.getPets();
 
     if (pets.length === 0) {
-        return (
-            <div className="mx-auto max-w-md">
-                <Card>
-                    <CardHeader>
-                        <CardTitle>No cats yet</CardTitle>
-                        <CardDescription>
-                            Add your first cat to start tracking weight and feedings.
-                        </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                        <Button asChild>
-                            <Link href="/dashboard/pets/new">Add a cat</Link>
-                        </Button>
-                    </CardContent>
-                </Card>
-            </div>
-        );
+        return <OnboardingWelcome />;
     }
 
     return <DashboardContent pets={pets} />;

--- a/src/app/dashboard/pets/[id]/_components/feeding-heatmap-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/feeding-heatmap-card.tsx
@@ -45,7 +45,13 @@ export function FeedingHeatmapCard({ petId }: { petId: number }) {
                     <Skeleton className="h-24 w-full" />
                 ) : (
                     <div className="overflow-x-auto">
-                        <div className="flex gap-[2px]">
+                        <div
+                            className="flex gap-[2px]"
+                            role="img"
+                            aria-label={`Feeding activity heatmap for the last 12 months — ${total} ${
+                                total === 1 ? "feeding" : "feedings"
+                            } logged.`}
+                        >
                             {cells.map((week, wi) => (
                                 <div
                                     key={wi}

--- a/src/app/dashboard/pets/[id]/_components/feeding-history-list.tsx
+++ b/src/app/dashboard/pets/[id]/_components/feeding-history-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { Utensils } from "lucide-react";
 
 import {
     Card,
@@ -10,6 +11,7 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { FeedingRowActions } from "~/app/dashboard/_components/feeding-row-actions";
+import { EmptyState } from "~/components/ui/empty-state";
 import { api } from "~/trpc/react";
 import { type RouterOutputs } from "~/trpc/react";
 
@@ -40,9 +42,11 @@ export function FeedingHistoryList({
                 {isLoading ? (
                     <p className="text-sm text-muted-foreground">Loading…</p>
                 ) : grouped.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No feedings recorded yet.
-                    </p>
+                    <EmptyState
+                        icon={Utensils}
+                        title="No feedings recorded yet"
+                        description="Logged meals will be grouped by day here."
+                    />
                 ) : (
                     <div className="space-y-5">
                         {grouped.map(({ dayKey, dayLabel, items, totalKcal }) => (

--- a/src/app/dashboard/pets/[id]/_components/health-events-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/health-events-card.tsx
@@ -20,6 +20,7 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "~/components/ui/dialog";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { api } from "~/trpc/react";
@@ -174,9 +175,11 @@ export function HealthEventsCard({
                 {isLoading ? (
                     <p className="text-sm text-muted-foreground">Loading…</p>
                 ) : !data || data.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No health events logged yet.
-                    </p>
+                    <EmptyState
+                        icon={HeartPulse}
+                        title="No health events yet"
+                        description="Log vet visits, vaccinations, symptoms, and more."
+                    />
                 ) : (
                     <ul className="divide-y">
                         {data.map((row) => (

--- a/src/app/dashboard/pets/[id]/_components/import-weight-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/import-weight-card.tsx
@@ -12,6 +12,8 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { useWeightUnit } from "~/hooks/use-weight-unit";
+import { toKg, type WeightUnit } from "~/lib/units";
 import { parseWeightCsv, type ParseResult } from "~/lib/weight-csv-parse";
 import { api } from "~/trpc/react";
 
@@ -22,8 +24,14 @@ export function ImportWeightCard({
     petId: number;
     canEdit: boolean;
 }) {
+    const preferredUnit = useWeightUnit();
     const inputRef = useRef<HTMLInputElement>(null);
     const [parsed, setParsed] = useState<ParseResult | null>(null);
+    // null = follow the user's preferred unit; set once they pick explicitly.
+    const [csvUnitOverride, setCsvUnitOverride] = useState<WeightUnit | null>(
+        null,
+    );
+    const csvUnit = csvUnitOverride ?? preferredUnit;
     const utils = api.useUtils();
     const bulkImport = api.weight.bulkImport.useMutation({
         onSuccess: async ({ inserted }) => {
@@ -48,7 +56,9 @@ export function ImportWeightCard({
             petId,
             entries: parsed.rows.map((r) => ({
                 weighedAt: r.weighedAt,
-                weight: r.weight,
+                // CSV values are interpreted in the selected unit and
+                // stored canonically as kg.
+                weight: toKg(r.weight, csvUnit),
             })),
         });
     }
@@ -75,6 +85,22 @@ export function ImportWeightCard({
                     }}
                     className="text-sm"
                 />
+                <div className="flex items-center gap-2 text-sm">
+                    <label htmlFor="csv-unit" className="text-muted-foreground">
+                        CSV weights are in
+                    </label>
+                    <select
+                        id="csv-unit"
+                        value={csvUnit}
+                        onChange={(e) =>
+                            setCsvUnitOverride(e.target.value as WeightUnit)
+                        }
+                        className="h-9 rounded-md border border-input bg-background px-2 text-sm"
+                    >
+                        <option value="kg">kilograms (kg)</option>
+                        <option value="lb">pounds (lb)</option>
+                    </select>
+                </div>
                 {parsed && (
                     <div className="space-y-2 text-sm">
                         <p>

--- a/src/app/dashboard/pets/[id]/_components/meds-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/meds-card.tsx
@@ -20,6 +20,7 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "~/components/ui/dialog";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { isMedDue, nextDueAt } from "~/lib/meds-due";
@@ -239,9 +240,11 @@ export function MedsCard({
                 {isLoading ? (
                     <p className="text-sm text-muted-foreground">Loading…</p>
                 ) : !data || data.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No medications yet.
-                    </p>
+                    <EmptyState
+                        icon={Pill}
+                        title="No medications yet"
+                        description="Add a recurring med to track doses and due times."
+                    />
                 ) : (
                     <ul className="divide-y">
                         {data.map((m) => {

--- a/src/app/dashboard/pets/[id]/_components/meds-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/meds-card.tsx
@@ -138,7 +138,7 @@ export function MedsCard({
                                         placeholder="Methimazole"
                                     />
                                 </div>
-                                <div className="grid grid-cols-2 gap-2">
+                                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                                     <div className="space-y-1">
                                         <Label htmlFor="med-dosage">
                                             Dosage
@@ -171,7 +171,7 @@ export function MedsCard({
                                         />
                                     </div>
                                 </div>
-                                <div className="grid grid-cols-2 gap-2">
+                                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                                     <div className="space-y-1">
                                         <Label htmlFor="med-starts">
                                             Starts

--- a/src/app/dashboard/pets/[id]/_components/notes-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/notes-card.tsx
@@ -12,6 +12,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { api } from "~/trpc/react";
 
 export function NotesCard({
@@ -84,9 +85,11 @@ export function NotesCard({
                 {isLoading ? (
                     <p className="text-sm text-muted-foreground">Loading…</p>
                 ) : !data || data.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No notes yet.
-                    </p>
+                    <EmptyState
+                        icon={NotebookPen}
+                        title="No notes yet"
+                        description="Jot down anything worth remembering about this pet."
+                    />
                 ) : (
                     <ul className="space-y-3">
                         {data.map((row) => (

--- a/src/app/dashboard/pets/[id]/_components/pet-edit-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/pet-edit-card.tsx
@@ -15,19 +15,24 @@ import {
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { PetAvatar } from "~/components/ui/pet-avatar";
+import { useWeightUnit } from "~/hooks/use-weight-unit";
+import { formatWeight, toKg } from "~/lib/units";
 import { api } from "~/trpc/react";
 import { type RouterOutputs } from "~/trpc/react";
 
 type Pet = RouterOutputs["pet"]["getPet"];
 
 export function PetEditCard({ pet }: { pet: Pet }) {
+    const unit = useWeightUnit();
     const [editing, setEditing] = useState(false);
     const [name, setName] = useState(pet.name);
     const [species, setSpecies] = useState(pet.species);
     const [gender, setGender] = useState(pet.gender);
     const [birthDate, setBirthDate] = useState(pet.birthDate ?? "");
     const [goalWeight, setGoalWeight] = useState(
-        pet.goalWeight !== null ? String(pet.goalWeight) : "",
+        pet.goalWeight !== null
+            ? formatWeight(pet.goalWeight, unit, { withUnit: false })
+            : "",
     );
     const [dailyKcalTarget, setDailyKcalTarget] = useState(
         pet.dailyKcalTarget !== null ? String(pet.dailyKcalTarget) : "",
@@ -74,9 +79,24 @@ export function PetEditCard({ pet }: { pet: Pet }) {
         onError: (err) => toast.error(err.message),
     });
 
+    function startEditing() {
+        // Seed the goal-weight field in the current unit, even if
+        // preferences loaded after this card first mounted.
+        setGoalWeight(
+            pet.goalWeight !== null
+                ? formatWeight(pet.goalWeight, unit, { withUnit: false })
+                : "",
+        );
+        setEditing(true);
+    }
+
     function onSubmit(event: FormEvent<HTMLFormElement>) {
         event.preventDefault();
-        const goal = goalWeight.trim() ? Number(goalWeight) : null;
+        const goalInUnit = goalWeight.trim() ? Number(goalWeight) : null;
+        const goal =
+            goalInUnit !== null && Number.isFinite(goalInUnit)
+                ? toKg(goalInUnit, unit)
+                : null;
         const kcal = dailyKcalTarget.trim() ? Number(dailyKcalTarget) : null;
         updatePet.mutate({
             petId: pet.id,
@@ -125,7 +145,7 @@ export function PetEditCard({ pet }: { pet: Pet }) {
                         type="button"
                         variant="outline"
                         size="sm"
-                        onClick={() => setEditing(true)}
+                        onClick={startEditing}
                     >
                         <Pencil className="mr-1 h-3.5 w-3.5" />
                         Edit
@@ -184,7 +204,9 @@ export function PetEditCard({ pet }: { pet: Pet }) {
                         </div>
                         <div className="grid grid-cols-2 gap-2">
                             <div className="space-y-1">
-                                <Label htmlFor="edit-goal">Goal weight</Label>
+                                <Label htmlFor="edit-goal">
+                                    Goal weight ({unit})
+                                </Label>
                                 <Input
                                     id="edit-goal"
                                     type="number"

--- a/src/app/dashboard/pets/[id]/_components/weight-history-list.tsx
+++ b/src/app/dashboard/pets/[id]/_components/weight-history-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Scale, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
@@ -13,6 +13,7 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
+import { EmptyState } from "~/components/ui/empty-state";
 import { useWeightUnit } from "~/hooks/use-weight-unit";
 import { formatWeight, toKg } from "~/lib/units";
 import { api } from "~/trpc/react";
@@ -42,9 +43,11 @@ export function WeightHistoryList({
                 {isLoading ? (
                     <p className="text-sm text-muted-foreground">Loading…</p>
                 ) : sorted.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No readings yet.
-                    </p>
+                    <EmptyState
+                        icon={Scale}
+                        title="No weight readings yet"
+                        description="Log a weight and it'll appear here."
+                    />
                 ) : (
                     <ul className="divide-y">
                         {sorted.map((row) => (

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -40,6 +40,7 @@ export default async function PetDetailPage({
 
     return (
         <div className="space-y-6">
+            <h1 className="sr-only">{pet.name}</h1>
             <div className="flex items-center justify-between">
                 <Button asChild variant="ghost" size="sm" className="-ml-2">
                     <Link href="/dashboard">

--- a/src/app/dashboard/pets/[id]/people/_components/people-manager.tsx
+++ b/src/app/dashboard/pets/[id]/people/_components/people-manager.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Copy, Trash2 } from "lucide-react";
+import { Copy, Trash2, Users } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
@@ -12,6 +12,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Label } from "~/components/ui/label";
 import { api } from "~/trpc/react";
 
@@ -85,9 +86,11 @@ export function PeopleManager({
                     {people.isLoading ? (
                         <p className="text-sm text-muted-foreground">Loading…</p>
                     ) : !people.data || people.data.length === 0 ? (
-                        <p className="text-sm text-muted-foreground">
-                            No one yet.
-                        </p>
+                        <EmptyState
+                            icon={Users}
+                            title="Just you so far"
+                            description="Share an invite link below to add other people."
+                        />
                     ) : (
                         <ul className="divide-y">
                             {people.data.map((p) => {

--- a/src/app/dashboard/settings/_components/delete-account-card.tsx
+++ b/src/app/dashboard/settings/_components/delete-account-card.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { useClerk } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import { AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "~/components/ui/dialog";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { api } from "~/trpc/react";
+
+const CONFIRM_PHRASE = "DELETE";
+
+export function DeleteAccountCard() {
+    const router = useRouter();
+    const { signOut } = useClerk();
+    const [open, setOpen] = useState(false);
+    const [confirmText, setConfirmText] = useState("");
+
+    const deleteAccount = api.account.deleteAccount.useMutation({
+        onSuccess: async () => {
+            toast.success("Account deleted");
+            await signOut();
+            router.push("/");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+
+    const canDelete =
+        confirmText === CONFIRM_PHRASE && !deleteAccount.isPending;
+
+    return (
+        <Card className="border-destructive/40">
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-destructive">
+                    <AlertTriangle className="h-4 w-4" />
+                    Danger zone
+                </CardTitle>
+                <CardDescription>
+                    Deleting your account removes your preferences and your
+                    access to every pet. Pets you solely own are deleted; pets
+                    shared with others are left for them. This cannot be
+                    undone.
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                <Dialog
+                    open={open}
+                    onOpenChange={(next) => {
+                        setOpen(next);
+                        if (!next) setConfirmText("");
+                    }}
+                >
+                    <DialogTrigger asChild>
+                        <Button type="button" variant="destructive" size="sm">
+                            Delete account
+                        </Button>
+                    </DialogTrigger>
+                    <DialogContent>
+                        <DialogHeader>
+                            <DialogTitle>Delete your account?</DialogTitle>
+                            <DialogDescription>
+                                This permanently deletes your preferences,
+                                your pet memberships, and any pet you solely
+                                own. Type{" "}
+                                <span className="font-mono font-semibold">
+                                    {CONFIRM_PHRASE}
+                                </span>{" "}
+                                to confirm.
+                            </DialogDescription>
+                        </DialogHeader>
+                        <div className="space-y-1">
+                            <Label htmlFor="confirm-delete">Confirmation</Label>
+                            <Input
+                                id="confirm-delete"
+                                value={confirmText}
+                                onChange={(e) =>
+                                    setConfirmText(e.target.value)
+                                }
+                                placeholder={CONFIRM_PHRASE}
+                                autoComplete="off"
+                            />
+                        </div>
+                        {deleteAccount.error && (
+                            <p className="text-sm text-destructive">
+                                {deleteAccount.error.message}
+                            </p>
+                        )}
+                        <DialogFooter>
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => setOpen(false)}
+                                disabled={deleteAccount.isPending}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                type="button"
+                                variant="destructive"
+                                disabled={!canDelete}
+                                onClick={() => deleteAccount.mutate()}
+                            >
+                                {deleteAccount.isPending
+                                    ? "Deleting…"
+                                    : "Delete account"}
+                            </Button>
+                        </DialogFooter>
+                    </DialogContent>
+                </Dialog>
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/settings/_components/settings-form.tsx
+++ b/src/app/dashboard/settings/_components/settings-form.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useMemo } from "react";
+import { Download } from "lucide-react";
 import { toast } from "sonner";
 
+import { Button } from "~/components/ui/button";
 import {
     Card,
     CardContent,
@@ -163,6 +165,24 @@ export function SettingsForm() {
                             </span>
                         </span>
                     </label>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Your data</CardTitle>
+                    <CardDescription>
+                        Download everything in your account — every pet you
+                        can see and its full history — as a JSON file.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <Button asChild variant="outline" size="sm">
+                        <a href="/api/account/export" download>
+                            <Download className="mr-2 h-3.5 w-3.5" />
+                            Export my data
+                        </a>
+                    </Button>
                 </CardContent>
             </Card>
         </div>

--- a/src/app/dashboard/settings/_components/settings-form.tsx
+++ b/src/app/dashboard/settings/_components/settings-form.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useMemo } from "react";
+import { toast } from "sonner";
+
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { Label } from "~/components/ui/label";
+import { Skeleton } from "~/components/ui/skeleton";
+import { type WeightUnit } from "~/lib/units";
+import { api } from "~/trpc/react";
+
+function listTimezones(): string[] {
+    try {
+        const supported = (
+            Intl as typeof Intl & {
+                supportedValuesOf?: (key: string) => string[];
+            }
+        ).supportedValuesOf?.("timeZone");
+        if (supported && supported.length > 0) return supported;
+    } catch {
+        // fall through to the minimal list
+    }
+    return ["UTC"];
+}
+
+export function SettingsForm() {
+    const utils = api.useUtils();
+    const { data, isLoading } = api.preferences.get.useQuery();
+    const timezones = useMemo(listTimezones, []);
+
+    const update = api.preferences.update.useMutation({
+        onMutate: async (patch) => {
+            await utils.preferences.get.cancel();
+            const previous = utils.preferences.get.getData();
+            if (previous) {
+                utils.preferences.get.setData(undefined, {
+                    ...previous,
+                    ...patch,
+                });
+            }
+            return { previous };
+        },
+        onError: (err, _patch, ctx) => {
+            if (ctx?.previous) {
+                utils.preferences.get.setData(undefined, ctx.previous);
+            }
+            toast.error(err.message);
+        },
+        onSuccess: () => toast.success("Settings saved"),
+        onSettled: () => void utils.preferences.get.invalidate(),
+    });
+
+    if (isLoading || !data) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-40 w-full" />
+                <Skeleton className="h-40 w-full" />
+                <Skeleton className="h-32 w-full" />
+            </div>
+        );
+    }
+
+    const pending = update.isPending;
+
+    return (
+        <div className="space-y-6">
+            <Card>
+                <CardHeader>
+                    <CardTitle>Units</CardTitle>
+                    <CardDescription>
+                        How weights are shown and entered. Stored values are
+                        unaffected — only the display changes.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <div className="space-y-1">
+                        <Label htmlFor="weight-unit">Weight unit</Label>
+                        <select
+                            id="weight-unit"
+                            value={data.weightUnit}
+                            disabled={pending}
+                            onChange={(e) =>
+                                update.mutate({
+                                    weightUnit: e.target.value as WeightUnit,
+                                })
+                            }
+                            className="flex h-10 w-full max-w-xs rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        >
+                            <option value="kg">Kilograms (kg)</option>
+                            <option value="lb">Pounds (lb)</option>
+                        </select>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Time zone</CardTitle>
+                    <CardDescription>
+                        Used for daily reminder timing and date grouping.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <div className="space-y-1">
+                        <Label htmlFor="timezone">Time zone</Label>
+                        <select
+                            id="timezone"
+                            value={data.timezone}
+                            disabled={pending}
+                            onChange={(e) =>
+                                update.mutate({ timezone: e.target.value })
+                            }
+                            className="flex h-10 w-full max-w-xs rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        >
+                            {timezones.includes(data.timezone) ? null : (
+                                <option value={data.timezone}>
+                                    {data.timezone}
+                                </option>
+                            )}
+                            {timezones.map((tz) => (
+                                <option key={tz} value={tz}>
+                                    {tz}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Notifications</CardTitle>
+                    <CardDescription>
+                        Email reminders for pets that haven&apos;t been fed.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <label className="flex items-start gap-3 text-sm">
+                        <input
+                            type="checkbox"
+                            checked={data.dailyRemindersEnabled}
+                            disabled={pending}
+                            onChange={(e) =>
+                                update.mutate({
+                                    dailyRemindersEnabled: e.target.checked,
+                                })
+                            }
+                            className="mt-0.5 h-4 w-4 rounded border-input"
+                        />
+                        <span>
+                            <span className="font-medium">
+                                Daily feeding reminders
+                            </span>
+                            <span className="block text-muted-foreground">
+                                Get an email when a pet you can edit
+                                hasn&apos;t been fed in a while.
+                            </span>
+                        </span>
+                    </label>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,19 @@
+import { SettingsForm } from "~/app/dashboard/settings/_components/settings-form";
+
+export const metadata = {
+    title: "Settings",
+};
+
+export default function SettingsPage() {
+    return (
+        <div className="mx-auto max-w-2xl space-y-6">
+            <div>
+                <h1 className="text-2xl font-semibold">Settings</h1>
+                <p className="text-sm text-muted-foreground">
+                    Preferences apply to your account across every pet.
+                </p>
+            </div>
+            <SettingsForm />
+        </div>
+    );
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,3 +1,4 @@
+import { DeleteAccountCard } from "~/app/dashboard/settings/_components/delete-account-card";
 import { SettingsForm } from "~/app/dashboard/settings/_components/settings-form";
 
 export const metadata = {
@@ -14,6 +15,7 @@ export default function SettingsPage() {
                 </p>
             </div>
             <SettingsForm />
+            <DeleteAccountCard />
         </div>
     );
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -30,10 +30,11 @@ const CardHeader = React.forwardRef<
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<
-    HTMLDivElement,
-    React.HTMLAttributes<HTMLDivElement>
+    HTMLHeadingElement,
+    React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
-    <div
+    // h3 so card titles land in the heading outline for screen-reader nav.
+    <h3
         ref={ref}
         className={cn(
             "text-lg font-semibold leading-none tracking-tight",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -35,7 +35,7 @@ const DialogContent = React.forwardRef<
         <DialogPrimitive.Content
             ref={ref}
             className={cn(
-                "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+                "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
                 className,
             )}
             {...props}

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,45 @@
+import { type LucideIcon } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+
+/**
+ * Consistent empty-state block: a muted icon chip, a short title, and an
+ * optional description. Pass children for a call-to-action button.
+ */
+export function EmptyState({
+    icon: Icon,
+    title,
+    description,
+    className,
+    children,
+}: {
+    icon?: LucideIcon;
+    title: string;
+    description?: string;
+    className?: string;
+    children?: React.ReactNode;
+}) {
+    return (
+        <div
+            className={cn(
+                "flex flex-col items-center justify-center gap-2 px-4 py-8 text-center",
+                className,
+            )}
+        >
+            {Icon && (
+                <div className="rounded-full bg-muted p-3">
+                    <Icon className="h-5 w-5 text-muted-foreground" />
+                </div>
+            )}
+            <div className="space-y-0.5">
+                <p className="text-sm font-medium">{title}</p>
+                {description && (
+                    <p className="text-sm text-muted-foreground">
+                        {description}
+                    </p>
+                )}
+            </div>
+            {children}
+        </div>
+    );
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,4 +1,5 @@
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
+import { accountRouter } from "~/server/api/routers/account";
 import { petRouter } from "~/server/api/routers/pet";
 import { weightRouter } from "~/server/api/routers/weight";
 import { feedingRouter } from "~/server/api/routers/feeding";
@@ -24,6 +25,7 @@ export const appRouter = createTRPCRouter({
   meds: medsRouter,
   notes: notesRouter,
   preferences: preferencesRouter,
+  account: accountRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/account.ts
+++ b/src/server/api/routers/account.ts
@@ -1,0 +1,60 @@
+import { clerkClient } from "@clerk/nextjs/server";
+import { and, count, eq, ne } from "drizzle-orm";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { petPeople, pets, userPreferences } from "~/server/db/schema";
+
+export const accountRouter = createTRPCRouter({
+    /**
+     * Permanently deletes the caller's account: soft-deletes any pet they
+     * solely own, drops every pet membership and their preferences, then
+     * removes the Clerk user. The `users` tombstone row is intentionally
+     * kept — petNotes / petInvites still FK to it.
+     *
+     * The DB work runs in one transaction; the Clerk deletion runs after
+     * it commits. If Clerk deletion fails the caller can safely retry —
+     * the DB steps are idempotent.
+     */
+    deleteAccount: protectedProcedure.mutation(async ({ ctx }) => {
+        const userId = ctx.userId;
+
+        await ctx.db.transaction(async (trx) => {
+            const memberships = await trx
+                .select({ petId: petPeople.petId, role: petPeople.role })
+                .from(petPeople)
+                .where(eq(petPeople.userId, userId));
+
+            for (const m of memberships) {
+                if (m.role !== "Owner") continue;
+                const [others] = await trx
+                    .select({ n: count() })
+                    .from(petPeople)
+                    .where(
+                        and(
+                            eq(petPeople.petId, m.petId),
+                            ne(petPeople.userId, userId),
+                        ),
+                    );
+                // Only soft-delete a pet the caller solely owns; pets with
+                // other people stay so co-owners keep their access.
+                if ((others?.n ?? 0) === 0) {
+                    await trx
+                        .update(pets)
+                        .set({ deletedAt: new Date() })
+                        .where(eq(pets.id, m.petId));
+                }
+            }
+
+            await trx
+                .delete(petPeople)
+                .where(eq(petPeople.userId, userId));
+            await trx
+                .delete(userPreferences)
+                .where(eq(userPreferences.userId, userId));
+        });
+
+        await clerkClient.users.deleteUser(userId);
+
+        return { ok: true as const };
+    }),
+});


### PR DESCRIPTION
## Summary
S54. The other half of unit support: all weight **inputs** collect the user's unit and convert to canonical kg with `toKg` before the mutation.

### Wired surfaces
- **RecordWeightDialog** — label is "Weight (kg|lb)", placeholder adapts, `toKg` before `recordWeight.mutate` (so the optimistic cache entry is already in kg)
- **ImportWeightCard** — new "CSV weights are in" `<select>`. Defaults to the user's preferred unit but follows it live until they pick explicitly (override pattern — `csvUnitOverride ?? preferredUnit`, no effect needed). Each parsed row is `toKg`'d on import.
- **PetEditCard** — goal-weight label shows the unit; the field is seeded in the active unit (re-seeded via `startEditing` so it's correct even if prefs load late) and converted back to kg on save

`new-pet-form` has no weight field — nothing to change there.

### Note on CSV round-trip
The per-pet CSV export (from S21) still emits raw kg. The import selector defaults to the user's display unit, so a lb user re-importing a kg export should switch the selector to `kg`. Making the export unit-aware is out of this batch's scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_