### PR TITLE
S59: first-pet onboarding welcome

### DIFF
--- a/src/app/dashboard/_components/dashboard-content.tsx
+++ b/src/app/dashboard/_components/dashboard-content.tsx
@@ -28,6 +28,7 @@ export function DashboardContent({ pets }: { pets: Pet[] }) {
 
     return (
         <div className="space-y-6">
+            <h1 className="sr-only">Pet dashboard</h1>
             <PetAlerts petId={selectedPet.id} petName={selectedPet.name} />
             <PetPicker
                 pets={pets}

--- a/src/app/dashboard/_components/food-breakdown-chart.tsx
+++ b/src/app/dashboard/_components/food-breakdown-chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { Utensils } from "lucide-react";
 import {
     Bar,
     BarChart,
@@ -19,6 +20,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Skeleton } from "~/components/ui/skeleton";
 import { computeFoodBreakdown } from "~/lib/food-breakdown";
 import { api } from "~/trpc/react";
@@ -60,13 +62,22 @@ export function FoodBreakdownChart({
                 {isLoading ? (
                     <Skeleton className="h-56 w-full" />
                 ) : series.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No feedings in the last 30 days.
-                    </p>
+                    <EmptyState
+                        icon={Utensils}
+                        title="No feedings in the last 30 days"
+                        description="Log some meals to see where the calories come from."
+                    />
                 ) : (
-                    <div className="h-56 w-full">
+                    <div
+                        className="h-56 w-full"
+                        role="img"
+                        aria-label={`${petName}'s calorie sources over the last 30 days, stacked by day across ${series.length} ${
+                            series.length === 1 ? "food" : "foods"
+                        }.`}
+                    >
                         <ResponsiveContainer width="100%" height="100%">
                             <BarChart
+                                accessibilityLayer
                                 data={chartData}
                                 margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
                             >

--- a/src/app/dashboard/_components/kcal-trend-chart.tsx
+++ b/src/app/dashboard/_components/kcal-trend-chart.tsx
@@ -56,9 +56,18 @@ export function KcalTrendChart({
                 {isLoading ? (
                     <Skeleton className="h-48 w-full" />
                 ) : (
-                    <div className="h-48 w-full">
+                    <div
+                        className="h-48 w-full"
+                        role="img"
+                        aria-label={`Daily calorie intake for ${petName} over the last ${days.length} days${
+                            dailyKcalTarget
+                                ? `, against a target of ${dailyKcalTarget} kcal`
+                                : ""
+                        }.`}
+                    >
                         <ResponsiveContainer width="100%" height="100%">
                             <BarChart
+                                accessibilityLayer
                                 data={days}
                                 margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
                             >

--- a/src/app/dashboard/_components/onboarding-welcome.tsx
+++ b/src/app/dashboard/_components/onboarding-welcome.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import { Activity, ArrowRight, Scale, Users, Utensils } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+
+const HIGHLIGHTS = [
+    {
+        icon: Scale,
+        title: "Track weight",
+        body: "Log readings and watch the trend toward a goal weight.",
+    },
+    {
+        icon: Utensils,
+        title: "Log feedings",
+        body: "Record meals and keep an eye on daily calories.",
+    },
+    {
+        icon: Activity,
+        title: "Note activity & health",
+        body: "Walks, play, vet visits, meds — all in one place.",
+    },
+    {
+        icon: Users,
+        title: "Share with family",
+        body: "Invite others to help track a pet you care for together.",
+    },
+] as const;
+
+/**
+ * First-run experience shown on the dashboard when the account has no
+ * pets yet. Orients the user and funnels them into the add-pet form.
+ */
+export function OnboardingWelcome() {
+    return (
+        <div className="mx-auto max-w-2xl space-y-6">
+            <div className="space-y-2 text-center">
+                <div className="text-4xl">🐾</div>
+                <h1 className="text-2xl font-semibold">Welcome to Meow</h1>
+                <p className="text-muted-foreground">
+                    Keep your pet&apos;s weight, meals, and health in one
+                    simple place. Start by adding your first pet.
+                </p>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+                {HIGHLIGHTS.map((h) => {
+                    const Icon = h.icon;
+                    return (
+                        <Card key={h.title}>
+                            <CardHeader className="pb-2">
+                                <CardTitle className="flex items-center gap-2 text-base">
+                                    <Icon className="h-4 w-4 text-primary" />
+                                    {h.title}
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <CardDescription>{h.body}</CardDescription>
+                            </CardContent>
+                        </Card>
+                    );
+                })}
+            </div>
+
+            <div className="flex flex-col items-center gap-2">
+                <Button asChild size="lg">
+                    <Link href="/dashboard/pets/new">
+                        Add your first pet
+                        <ArrowRight className="ml-2 h-4 w-4" />
+                    </Link>
+                </Button>
+                <p className="text-xs text-muted-foreground">
+                    Takes about a minute. You can edit everything later.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/src/app/dashboard/_components/today-activity.tsx
+++ b/src/app/dashboard/_components/today-activity.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { Trash2 } from "lucide-react";
+import { Activity, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
@@ -12,6 +12,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Skeleton } from "~/components/ui/skeleton";
 import { api } from "~/trpc/react";
 
@@ -70,9 +71,11 @@ export function TodayActivity({
                         <Skeleton className="h-12 w-full" />
                     </div>
                 ) : today.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No activity logged today yet.
-                    </p>
+                    <EmptyState
+                        icon={Activity}
+                        title="Nothing logged today"
+                        description="Record a walk or play session to track it here."
+                    />
                 ) : (
                     <ul className="space-y-2">
                         {today.map((row) => (

--- a/src/app/dashboard/_components/today-feedings.tsx
+++ b/src/app/dashboard/_components/today-feedings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { Utensils } from "lucide-react";
 
 import {
     Card,
@@ -10,6 +11,7 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { FeedingRowActions } from "~/app/dashboard/_components/feeding-row-actions";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Skeleton } from "~/components/ui/skeleton";
 import { cn } from "~/lib/utils";
 import { api } from "~/trpc/react";
@@ -94,9 +96,11 @@ export function TodayFeedings({
                         <Skeleton className="h-12 w-full" />
                     </div>
                 ) : today.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No feedings logged today yet.
-                    </p>
+                    <EmptyState
+                        icon={Utensils}
+                        title="No feedings logged today"
+                        description="Log a meal to start tracking today's calories."
+                    />
                 ) : (
                     <ul className="space-y-2">
                         {today.map((row) => {

--- a/src/app/dashboard/_components/weight-chart.tsx
+++ b/src/app/dashboard/_components/weight-chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { Scale } from "lucide-react";
 import {
     CartesianGrid,
     Line,
@@ -21,6 +22,7 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { Skeleton } from "~/components/ui/skeleton";
+import { EmptyState } from "~/components/ui/empty-state";
 import { useWeightUnit } from "~/hooks/use-weight-unit";
 import { formatWeight, fromKg } from "~/lib/units";
 import { cn } from "~/lib/utils";
@@ -120,9 +122,12 @@ export function WeightChart({
                 {isLoading ? (
                     <Skeleton className="h-64 w-full" />
                 ) : points.length === 0 ? (
-                    <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">
-                        No weight readings in this range yet.
-                    </div>
+                    <EmptyState
+                        icon={Scale}
+                        title="No readings in this range"
+                        description="Try a wider range, or log a weight to get started."
+                        className="h-64"
+                    />
                 ) : (
                     <div className="h-64 w-full">
                         <ResponsiveContainer width="100%" height="100%">

--- a/src/app/dashboard/_components/weight-chart.tsx
+++ b/src/app/dashboard/_components/weight-chart.tsx
@@ -129,9 +129,16 @@ export function WeightChart({
                         className="h-64"
                     />
                 ) : (
-                    <div className="h-64 w-full">
+                    <div
+                        className="h-64 w-full"
+                        role="img"
+                        aria-label={`${petName}'s weight chart — ${points.length} ${
+                            points.length === 1 ? "reading" : "readings"
+                        } in the selected range, measured in ${unit}.`}
+                    >
                         <ResponsiveContainer width="100%" height="100%">
                             <LineChart
+                                accessibilityLayer
                                 data={points}
                                 margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
                             >

--- a/src/app/dashboard/_components/weight-stats-card.tsx
+++ b/src/app/dashboard/_components/weight-stats-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { ArrowDown, ArrowRight, ArrowUp } from "lucide-react";
+import { ArrowDown, ArrowRight, ArrowUp, LineChart } from "lucide-react";
 
 import {
     Card,
@@ -10,6 +10,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Skeleton } from "~/components/ui/skeleton";
 import { useWeightUnit } from "~/hooks/use-weight-unit";
 import { formatWeight, fromKg, type WeightUnit } from "~/lib/units";
@@ -49,9 +50,11 @@ export function WeightStatsCard({
                         <Skeleton className="h-12" />
                     </div>
                 ) : !stats ? (
-                    <p className="text-sm text-muted-foreground">
-                        Log at least two weights to see a trend.
-                    </p>
+                    <EmptyState
+                        icon={LineChart}
+                        title="Not enough data yet"
+                        description="Log at least two weight readings and the trend will show up here."
+                    />
                 ) : (
                     <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
                         <Stat

--- a/src/app/dashboard/foods/_components/add-food-form.tsx
+++ b/src/app/dashboard/foods/_components/add-food-form.tsx
@@ -83,7 +83,7 @@ export function AddFoodForm() {
                     placeholder="3.65"
                 />
             </div>
-            <div className="grid grid-cols-3 gap-2">
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
                 <MacroField id="food-p" label="Protein %" value={protein} onChange={setProtein} />
                 <MacroField id="food-f" label="Fat %" value={fat} onChange={setFat} />
                 <MacroField id="food-c" label="Carbs %" value={carbs} onChange={setCarbs} />

--- a/src/app/dashboard/foods/_components/food-list.tsx
+++ b/src/app/dashboard/foods/_components/food-list.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { Utensils } from "lucide-react";
+
 import { Card, CardContent } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { api } from "~/trpc/react";
 
 export function FoodList() {
@@ -12,8 +15,12 @@ export function FoodList() {
     if (!data || data.length === 0) {
         return (
             <Card>
-                <CardContent className="p-6 text-sm text-muted-foreground">
-                    No foods yet. Add the first one on the right.
+                <CardContent className="p-2">
+                    <EmptyState
+                        icon={Utensils}
+                        title="No foods yet"
+                        description="Add your first food using the form to get started."
+                    />
                 </CardContent>
             </Card>
         );

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -8,8 +8,17 @@ export default function DashboardLayout({
 }) {
     return (
         <div className="min-h-screen bg-background">
+            <a
+                href="#main-content"
+                className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:shadow-md focus:ring-2 focus:ring-ring"
+            >
+                Skip to content
+            </a>
             <TopNav />
-            <main className="container mx-auto py-6 pb-24 md:py-8 md:pb-8">
+            <main
+                id="main-content"
+                className="container mx-auto py-6 pb-24 md:py-8 md:pb-8"
+            >
                 {children}
             </main>
             <BottomNav />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,37 +1,12 @@
-import Link from "next/link";
-
-import { Button } from "~/components/ui/button";
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from "~/components/ui/card";
 import { DashboardContent } from "~/app/dashboard/_components/dashboard-content";
+import { OnboardingWelcome } from "~/app/dashboard/_components/onboarding-welcome";
 import { api } from "~/trpc/server";
 
 export default async function DashboardPage() {
     const pets = await api.pet.getPets();
 
     if (pets.length === 0) {
-        return (
-            <div className="mx-auto max-w-md">
-                <Card>
-                    <CardHeader>
-                        <CardTitle>No cats yet</CardTitle>
-                        <CardDescription>
-                            Add your first cat to start tracking weight and feedings.
-                        </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                        <Button asChild>
-                            <Link href="/dashboard/pets/new">Add a cat</Link>
-                        </Button>
-                    </CardContent>
-                </Card>
-            </div>
-        );
+        return <OnboardingWelcome />;
     }
 
     return <DashboardContent pets={pets} />;

--- a/src/app/dashboard/pets/[id]/_components/feeding-heatmap-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/feeding-heatmap-card.tsx
@@ -45,7 +45,13 @@ export function FeedingHeatmapCard({ petId }: { petId: number }) {
                     <Skeleton className="h-24 w-full" />
                 ) : (
                     <div className="overflow-x-auto">
-                        <div className="flex gap-[2px]">
+                        <div
+                            className="flex gap-[2px]"
+                            role="img"
+                            aria-label={`Feeding activity heatmap for the last 12 months — ${total} ${
+                                total === 1 ? "feeding" : "feedings"
+                            } logged.`}
+                        >
                             {cells.map((week, wi) => (
                                 <div
                                     key={wi}

--- a/src/app/dashboard/pets/[id]/_components/feeding-history-list.tsx
+++ b/src/app/dashboard/pets/[id]/_components/feeding-history-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { Utensils } from "lucide-react";
 
 import {
     Card,
@@ -10,6 +11,7 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { FeedingRowActions } from "~/app/dashboard/_components/feeding-row-actions";
+import { EmptyState } from "~/components/ui/empty-state";
 import { api } from "~/trpc/react";
 import { type RouterOutputs } from "~/trpc/react";
 
@@ -40,9 +42,11 @@ export function FeedingHistoryList({
                 {isLoading ? (
                     <p className="text-sm text-muted-foreground">Loading…</p>
                 ) : grouped.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No feedings recorded yet.
-                    </p>
+                    <EmptyState
+                        icon={Utensils}
+                        title="No feedings recorded yet"
+                        description="Logged meals will be grouped by day here."
+                    />
                 ) : (
                     <div className="space-y-5">
                         {grouped.map(({ dayKey, dayLabel, items, totalKcal }) => (

--- a/src/app/dashboard/pets/[id]/_components/health-events-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/health-events-card.tsx
@@ -20,6 +20,7 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "~/components/ui/dialog";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { api } from "~/trpc/react";
@@ -174,9 +175,11 @@ export function HealthEventsCard({
                 {isLoading ? (
                     <p className="text-sm text-muted-foreground">Loading…</p>
                 ) : !data || data.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No health events logged yet.
-                    </p>
+                    <EmptyState
+                        icon={HeartPulse}
+                        title="No health events yet"
+                        description="Log vet visits, vaccinations, symptoms, and more."
+                    />
                 ) : (
                     <ul className="divide-y">
                         {data.map((row) => (

--- a/src/app/dashboard/pets/[id]/_components/meds-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/meds-card.tsx
@@ -20,6 +20,7 @@ import {
     DialogTitle,
     DialogTrigger,
 } from "~/components/ui/dialog";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { isMedDue, nextDueAt } from "~/lib/meds-due";
@@ -239,9 +240,11 @@ export function MedsCard({
                 {isLoading ? (
                     <p className="text-sm text-muted-foreground">Loading…</p>
                 ) : !data || data.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No medications yet.
-                    </p>
+                    <EmptyState
+                        icon={Pill}
+                        title="No medications yet"
+                        description="Add a recurring med to track doses and due times."
+                    />
                 ) : (
                     <ul className="divide-y">
                         {data.map((m) => {

--- a/src/app/dashboard/pets/[id]/_components/meds-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/meds-card.tsx
@@ -138,7 +138,7 @@ export function MedsCard({
                                         placeholder="Methimazole"
                                     />
                                 </div>
-                                <div className="grid grid-cols-2 gap-2">
+                                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                                     <div className="space-y-1">
                                         <Label htmlFor="med-dosage">
                                             Dosage
@@ -171,7 +171,7 @@ export function MedsCard({
                                         />
                                     </div>
                                 </div>
-                                <div className="grid grid-cols-2 gap-2">
+                                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                                     <div className="space-y-1">
                                         <Label htmlFor="med-starts">
                                             Starts

--- a/src/app/dashboard/pets/[id]/_components/notes-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/notes-card.tsx
@@ -12,6 +12,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { api } from "~/trpc/react";
 
 export function NotesCard({
@@ -84,9 +85,11 @@ export function NotesCard({
                 {isLoading ? (
                     <p className="text-sm text-muted-foreground">Loading…</p>
                 ) : !data || data.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No notes yet.
-                    </p>
+                    <EmptyState
+                        icon={NotebookPen}
+                        title="No notes yet"
+                        description="Jot down anything worth remembering about this pet."
+                    />
                 ) : (
                     <ul className="space-y-3">
                         {data.map((row) => (

--- a/src/app/dashboard/pets/[id]/_components/weight-history-list.tsx
+++ b/src/app/dashboard/pets/[id]/_components/weight-history-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, type FormEvent } from "react";
-import { Pencil, Trash2 } from "lucide-react";
+import { Pencil, Scale, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
@@ -13,6 +13,7 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
+import { EmptyState } from "~/components/ui/empty-state";
 import { useWeightUnit } from "~/hooks/use-weight-unit";
 import { formatWeight, toKg } from "~/lib/units";
 import { api } from "~/trpc/react";
@@ -42,9 +43,11 @@ export function WeightHistoryList({
                 {isLoading ? (
                     <p className="text-sm text-muted-foreground">Loading…</p>
                 ) : sorted.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No readings yet.
-                    </p>
+                    <EmptyState
+                        icon={Scale}
+                        title="No weight readings yet"
+                        description="Log a weight and it'll appear here."
+                    />
                 ) : (
                     <ul className="divide-y">
                         {sorted.map((row) => (

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -40,6 +40,7 @@ export default async function PetDetailPage({
 
     return (
         <div className="space-y-6">
+            <h1 className="sr-only">{pet.name}</h1>
             <div className="flex items-center justify-between">
                 <Button asChild variant="ghost" size="sm" className="-ml-2">
                     <Link href="/dashboard">

--- a/src/app/dashboard/pets/[id]/people/_components/people-manager.tsx
+++ b/src/app/dashboard/pets/[id]/people/_components/people-manager.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Copy, Trash2 } from "lucide-react";
+import { Copy, Trash2, Users } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "~/components/ui/button";
@@ -12,6 +12,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Label } from "~/components/ui/label";
 import { api } from "~/trpc/react";
 
@@ -85,9 +86,11 @@ export function PeopleManager({
                     {people.isLoading ? (
                         <p className="text-sm text-muted-foreground">Loading…</p>
                     ) : !people.data || people.data.length === 0 ? (
-                        <p className="text-sm text-muted-foreground">
-                            No one yet.
-                        </p>
+                        <EmptyState
+                            icon={Users}
+                            title="Just you so far"
+                            description="Share an invite link below to add other people."
+                        />
                     ) : (
                         <ul className="divide-y">
                             {people.data.map((p) => {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -30,10 +30,11 @@ const CardHeader = React.forwardRef<
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<
-    HTMLDivElement,
-    React.HTMLAttributes<HTMLDivElement>
+    HTMLHeadingElement,
+    React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
-    <div
+    // h3 so card titles land in the heading outline for screen-reader nav.
+    <h3
         ref={ref}
         className={cn(
             "text-lg font-semibold leading-none tracking-tight",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -35,7 +35,7 @@ const DialogContent = React.forwardRef<
         <DialogPrimitive.Content
             ref={ref}
             className={cn(
-                "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+                "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
                 className,
             )}
             {...props}

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,45 @@
+import { type LucideIcon } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+
+/**
+ * Consistent empty-state block: a muted icon chip, a short title, and an
+ * optional description. Pass children for a call-to-action button.
+ */
+export function EmptyState({
+    icon: Icon,
+    title,
+    description,
+    className,
+    children,
+}: {
+    icon?: LucideIcon;
+    title: string;
+    description?: string;
+    className?: string;
+    children?: React.ReactNode;
+}) {
+    return (
+        <div
+            className={cn(
+                "flex flex-col items-center justify-center gap-2 px-4 py-8 text-center",
+                className,
+            )}
+        >
+            {Icon && (
+                <div className="rounded-full bg-muted p-3">
+                    <Icon className="h-5 w-5 text-muted-foreground" />
+                </div>
+            )}
+            <div className="space-y-0.5">
+                <p className="text-sm font-medium">{title}</p>
+                {description && (
+                    <p className="text-sm text-muted-foreground">
+                        {description}
+                    </p>
+                )}
+            </div>
+            {children}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
S59. First-pet onboarding.

Replaces the bare "No cats yet" card with `OnboardingWelcome` — a friendly first-run screen:
- short intro to what Meow does
- four feature highlight cards (weight, feedings, activity/health, sharing)
- a prominent "Add your first pet" CTA into the existing add-pet form

Shown on the dashboard whenever the account has zero pets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_