### PR TITLE
S62: accessibility pass

### DIFF
--- a/src/app/dashboard/_components/dashboard-content.tsx
+++ b/src/app/dashboard/_components/dashboard-content.tsx
@@ -28,6 +28,7 @@ export function DashboardContent({ pets }: { pets: Pet[] }) {
 
     return (
         <div className="space-y-6">
+            <h1 className="sr-only">Pet dashboard</h1>
             <PetAlerts petId={selectedPet.id} petName={selectedPet.name} />
             <PetPicker
                 pets={pets}

--- a/src/app/dashboard/_components/food-breakdown-chart.tsx
+++ b/src/app/dashboard/_components/food-breakdown-chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { Utensils } from "lucide-react";
 import {
     Bar,
     BarChart,
@@ -19,6 +20,7 @@ import {
     CardHeader,
     CardTitle,
 } from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
 import { Skeleton } from "~/components/ui/skeleton";
 import { computeFoodBreakdown } from "~/lib/food-breakdown";
 import { api } from "~/trpc/react";
@@ -60,13 +62,22 @@ export function FoodBreakdownChart({
                 {isLoading ? (
                     <Skeleton className="h-56 w-full" />
                 ) : series.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                        No feedings in the last 30 days.
-                    </p>
+                    <EmptyState
+                        icon={Utensils}
+                        title="No feedings in the last 30 days"
+                        description="Log some meals to see where the calories come from."
+                    />
                 ) : (
-                    <div className="h-56 w-full">
+                    <div
+                        className="h-56 w-full"
+                        role="img"
+                        aria-label={`${petName}'s calorie sources over the last 30 days, stacked by day across ${series.length} ${
+                            series.length === 1 ? "food" : "foods"
+                        }.`}
+                    >
                         <ResponsiveContainer width="100%" height="100%">
                             <BarChart
+                                accessibilityLayer
                                 data={chartData}
                                 margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
                             >

--- a/src/app/dashboard/_components/kcal-trend-chart.tsx
+++ b/src/app/dashboard/_components/kcal-trend-chart.tsx
@@ -56,9 +56,18 @@ export function KcalTrendChart({
                 {isLoading ? (
                     <Skeleton className="h-48 w-full" />
                 ) : (
-                    <div className="h-48 w-full">
+                    <div
+                        className="h-48 w-full"
+                        role="img"
+                        aria-label={`Daily calorie intake for ${petName} over the last ${days.length} days${
+                            dailyKcalTarget
+                                ? `, against a target of ${dailyKcalTarget} kcal`
+                                : ""
+                        }.`}
+                    >
                         <ResponsiveContainer width="100%" height="100%">
                             <BarChart
+                                accessibilityLayer
                                 data={days}
                                 margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
                             >

--- a/src/app/dashboard/_components/weight-chart.tsx
+++ b/src/app/dashboard/_components/weight-chart.tsx
@@ -129,9 +129,16 @@ export function WeightChart({
                         className="h-64"
                     />
                 ) : (
-                    <div className="h-64 w-full">
+                    <div
+                        className="h-64 w-full"
+                        role="img"
+                        aria-label={`${petName}'s weight chart — ${points.length} ${
+                            points.length === 1 ? "reading" : "readings"
+                        } in the selected range, measured in ${unit}.`}
+                    >
                         <ResponsiveContainer width="100%" height="100%">
                             <LineChart
+                                accessibilityLayer
                                 data={points}
                                 margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
                             >

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -8,8 +8,17 @@ export default function DashboardLayout({
 }) {
     return (
         <div className="min-h-screen bg-background">
+            <a
+                href="#main-content"
+                className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:shadow-md focus:ring-2 focus:ring-ring"
+            >
+                Skip to content
+            </a>
             <TopNav />
-            <main className="container mx-auto py-6 pb-24 md:py-8 md:pb-8">
+            <main
+                id="main-content"
+                className="container mx-auto py-6 pb-24 md:py-8 md:pb-8"
+            >
                 {children}
             </main>
             <BottomNav />

--- a/src/app/dashboard/pets/[id]/_components/feeding-heatmap-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/feeding-heatmap-card.tsx
@@ -45,7 +45,13 @@ export function FeedingHeatmapCard({ petId }: { petId: number }) {
                     <Skeleton className="h-24 w-full" />
                 ) : (
                     <div className="overflow-x-auto">
-                        <div className="flex gap-[2px]">
+                        <div
+                            className="flex gap-[2px]"
+                            role="img"
+                            aria-label={`Feeding activity heatmap for the last 12 months — ${total} ${
+                                total === 1 ? "feeding" : "feedings"
+                            } logged.`}
+                        >
                             {cells.map((week, wi) => (
                                 <div
                                     key={wi}

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -40,6 +40,7 @@ export default async function PetDetailPage({
 
     return (
         <div className="space-y-6">
+            <h1 className="sr-only">{pet.name}</h1>
             <div className="flex items-center justify-between">
                 <Button asChild variant="ghost" size="sm" className="-ml-2">
                     <Link href="/dashboard">

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -30,10 +30,11 @@ const CardHeader = React.forwardRef<
 CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<
-    HTMLDivElement,
-    React.HTMLAttributes<HTMLDivElement>
+    HTMLHeadingElement,
+    React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
-    <div
+    // h3 so card titles land in the heading outline for screen-reader nav.
+    <h3
         ref={ref}
         className={cn(
             "text-lg font-semibold leading-none tracking-tight",


### PR DESCRIPTION
## Summary
S62 (final story of Batch 6). Accessibility pass.

### Changes
- **`CardTitle`** now renders an `<h3>` instead of a `<div>`, so every card title lands in the heading outline for screen-reader navigation. Styling unchanged.
- **Skip link** — dashboard layout gets a "Skip to content" link (visible on focus) targeting a new `id="main-content"` on `<main>`.
- **`sr-only` `<h1>`** added to the pet dashboard and pet detail pages, which previously had no top-level heading.
- **Charts** were opaque to screen readers. `WeightChart`, `KcalTrendChart`, and `FoodBreakdownChart` now wrap their plot area in `role="img"` with a descriptive `aria-label`, and pass `accessibilityLayer` to the recharts component for keyboard support. The feeding heatmap grid gets the same `role="img"` + summary label.
- Aligned `food-breakdown-chart`'s empty state with the S60 `EmptyState` component (missed in that pass).

### Audit notes
Icon-only buttons across the app already had `aria-label`s — no changes needed there. `<select>` elements all have associated `<Label>`s.

---
This is the last of Batch 6 (S52–S62). Full stack: S52 prefs table → S53/S54 kg-lb → S55 settings page → S56 cron → S57 export → S58 deletion → S59 onboarding → S60 empty states → S61 mobile → S62 a11y.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_