### PR TITLE
Batch 7: photos, appointments, timeline, comparison, reports

### DIFF
--- a/drizzle/0011_flawless_hobgoblin.sql
+++ b/drizzle/0011_flawless_hobgoblin.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS "meow-weight-tracker_pet_photos" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"pet_id" integer NOT NULL,
+	"url" varchar(1024) NOT NULL,
+	"caption" varchar(256),
+	"taken_at" timestamp with time zone NOT NULL,
+	"uploaded_by" varchar(256) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "meow-weight-tracker_pet_photos" ADD CONSTRAINT "meow-weight-tracker_pet_photos_pet_id_meow-weight-tracker_pets_id_fk" FOREIGN KEY ("pet_id") REFERENCES "public"."meow-weight-tracker_pets"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "meow-weight-tracker_pet_photos" ADD CONSTRAINT "meow-weight-tracker_pet_photos_uploaded_by_meow-weight-tracker_users_id_fk" FOREIGN KEY ("uploaded_by") REFERENCES "public"."meow-weight-tracker_users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "pet_photos_pet_id_idx" ON "meow-weight-tracker_pet_photos" ("pet_id");

--- a/drizzle/0012_nostalgic_rafael_vega.sql
+++ b/drizzle/0012_nostalgic_rafael_vega.sql
@@ -1,0 +1,33 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."appointment_status" AS ENUM('Scheduled', 'Completed', 'Cancelled');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "meow-weight-tracker_pet_appointments" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"pet_id" integer NOT NULL,
+	"title" varchar(256) NOT NULL,
+	"appointment_type" varchar(64) NOT NULL,
+	"scheduled_for" timestamp with time zone NOT NULL,
+	"location" varchar(256),
+	"notes" varchar(2048),
+	"status" "appointment_status" DEFAULT 'Scheduled' NOT NULL,
+	"created_by" varchar(256) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "meow-weight-tracker_pet_appointments" ADD CONSTRAINT "meow-weight-tracker_pet_appointments_pet_id_meow-weight-tracker_pets_id_fk" FOREIGN KEY ("pet_id") REFERENCES "public"."meow-weight-tracker_pets"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "meow-weight-tracker_pet_appointments" ADD CONSTRAINT "meow-weight-tracker_pet_appointments_created_by_meow-weight-tracker_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."meow-weight-tracker_users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "pet_appointments_pet_id_idx" ON "meow-weight-tracker_pet_appointments" ("pet_id");

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1114 @@
+{
+  "id": "78463a20-84ac-4294-b963-48832b34a861",
+  "prevId": "0ee9bf5a-430e-49ed-a582-63e6d70e7b87",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.meow-weight-tracker_activity_history": {
+      "name": "meow-weight-tracker_activity_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_history_pet_id_idx": {
+          "name": "activity_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_activity_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_eating_history": {
+      "name": "meow-weight-tracker_eating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fed_at": {
+          "name": "fed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_grams": {
+          "name": "quantity_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eating_history_pet_id_idx": {
+          "name": "eating_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk": {
+          "name": "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pet_food",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_health_events": {
+      "name": "meow-weight-tracker_health_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_events_pet_id_idx": {
+          "name": "health_events_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_health_events",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_food": {
+      "name": "meow-weight-tracker_pet_food",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories_per_gram": {
+          "name": "calories_per_gram",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_percent": {
+          "name": "protein_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat_percent": {
+          "name": "fat_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs_percent": {
+          "name": "carbs_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_food_name_idx": {
+          "name": "pet_food_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_invites": {
+      "name": "meow-weight-tracker_pet_invites",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_invites_pet_id_idx": {
+          "name": "pet_invites_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_meds": {
+      "name": "meow-weight-tracker_pet_meds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_hours": {
+          "name": "frequency_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_given_at": {
+          "name": "last_given_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_meds_pet_id_idx": {
+          "name": "pet_meds_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_meds_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_meds_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_meds",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_notes": {
+      "name": "meow-weight-tracker_pet_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_by": {
+          "name": "written_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_notes_pet_id_idx": {
+          "name": "pet_notes_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_notes",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_notes",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "written_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_people": {
+      "name": "meow-weight-tracker_pet_people",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_people_user_id_idx": {
+          "name": "pet_people_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "pet_people_pet_id_idx": {
+          "name": "pet_people_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meow-weight-tracker_pet_people_user_id_pet_id_pk": {
+          "name": "meow-weight-tracker_pet_people_user_id_pet_id_pk",
+          "columns": [
+            "user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_photos": {
+      "name": "meow-weight-tracker_pet_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taken_at": {
+          "name": "taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_photos_pet_id_idx": {
+          "name": "pet_photos_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_photos_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_photos_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_photos",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_photos_uploaded_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_photos_uploaded_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_photos",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pets": {
+      "name": "meow-weight-tracker_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_weight": {
+          "name": "goal_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_kcal_target": {
+          "name": "daily_kcal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_user_preferences": {
+      "name": "meow-weight-tracker_user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "weight_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'kg'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "daily_reminders_enabled": {
+          "name": "daily_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meow-weight-tracker_user_preferences_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_user_preferences_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_user_preferences",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_users": {
+      "name": "meow-weight-tracker_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_weight_history": {
+      "name": "meow-weight-tracker_weight_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weighed_at": {
+          "name": "weighed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weight_history_pet_id_idx": {
+          "name": "weight_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_weight_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.pet_role": {
+      "name": "pet_role",
+      "schema": "public",
+      "values": [
+        "Owner",
+        "Editor",
+        "Viewer"
+      ]
+    },
+    "public.weight_unit": {
+      "name": "weight_unit",
+      "schema": "public",
+      "values": [
+        "kg",
+        "lb"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1238 @@
+{
+  "id": "87611ede-8a64-46a3-a52b-35255778db30",
+  "prevId": "78463a20-84ac-4294-b963-48832b34a861",
+  "version": "6",
+  "dialect": "postgresql",
+  "tables": {
+    "public.meow-weight-tracker_activity_history": {
+      "name": "meow-weight-tracker_activity_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_history_pet_id_idx": {
+          "name": "activity_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_activity_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_activity_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_eating_history": {
+      "name": "meow-weight-tracker_eating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "food_id": {
+          "name": "food_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fed_at": {
+          "name": "fed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_grams": {
+          "name": "quantity_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eating_history_pet_id_idx": {
+          "name": "eating_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_eating_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk": {
+          "name": "meow-weight-tracker_eating_history_food_id_meow-weight-tracker_pet_food_id_fk",
+          "tableFrom": "meow-weight-tracker_eating_history",
+          "tableTo": "meow-weight-tracker_pet_food",
+          "columnsFrom": [
+            "food_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_health_events": {
+      "name": "meow-weight-tracker_health_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "health_events_pet_id_idx": {
+          "name": "health_events_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_health_events_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_health_events",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_appointments": {
+      "name": "meow-weight-tracker_pet_appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_type": {
+          "name": "appointment_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Scheduled'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_appointments_pet_id_idx": {
+          "name": "pet_appointments_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_appointments_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_appointments_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_appointments",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_appointments_created_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_appointments_created_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_appointments",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_food": {
+      "name": "meow-weight-tracker_pet_food",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calories_per_gram": {
+          "name": "calories_per_gram",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protein_percent": {
+          "name": "protein_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fat_percent": {
+          "name": "fat_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carbs_percent": {
+          "name": "carbs_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_food_name_idx": {
+          "name": "pet_food_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_invites": {
+      "name": "meow-weight-tracker_pet_invites",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_invites_pet_id_idx": {
+          "name": "pet_invites_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_created_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_invites_accepted_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_invites",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "accepted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_meds": {
+      "name": "meow-weight-tracker_pet_meds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_hours": {
+          "name": "frequency_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_given_at": {
+          "name": "last_given_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_meds_pet_id_idx": {
+          "name": "pet_meds_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_meds_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_meds_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_meds",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_notes": {
+      "name": "meow-weight-tracker_pet_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_by": {
+          "name": "written_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_notes_pet_id_idx": {
+          "name": "pet_notes_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_notes_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_notes",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_notes_written_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_notes",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "written_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_people": {
+      "name": "meow-weight-tracker_pet_people",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "pet_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_people_user_id_idx": {
+          "name": "pet_people_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "pet_people_pet_id_idx": {
+          "name": "pet_people_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_people_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_people_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_people",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "meow-weight-tracker_pet_people_user_id_pet_id_pk": {
+          "name": "meow-weight-tracker_pet_people_user_id_pet_id_pk",
+          "columns": [
+            "user_id",
+            "pet_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pet_photos": {
+      "name": "meow-weight-tracker_pet_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taken_at": {
+          "name": "taken_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_photos_pet_id_idx": {
+          "name": "pet_photos_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_pet_photos_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_pet_photos_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_photos",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meow-weight-tracker_pet_photos_uploaded_by_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_pet_photos_uploaded_by_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_pet_photos",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_pets": {
+      "name": "meow-weight-tracker_pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_weight": {
+          "name": "goal_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_kcal_target": {
+          "name": "daily_kcal_target",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_user_preferences": {
+      "name": "meow-weight-tracker_user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "weight_unit": {
+          "name": "weight_unit",
+          "type": "weight_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'kg'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "daily_reminders_enabled": {
+          "name": "daily_reminders_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meow-weight-tracker_user_preferences_user_id_meow-weight-tracker_users_id_fk": {
+          "name": "meow-weight-tracker_user_preferences_user_id_meow-weight-tracker_users_id_fk",
+          "tableFrom": "meow-weight-tracker_user_preferences",
+          "tableTo": "meow-weight-tracker_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_users": {
+      "name": "meow-weight-tracker_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.meow-weight-tracker_weight_history": {
+      "name": "meow-weight-tracker_weight_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weighed_at": {
+          "name": "weighed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "weight_history_pet_id_idx": {
+          "name": "weight_history_pet_id_idx",
+          "columns": [
+            "pet_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk": {
+          "name": "meow-weight-tracker_weight_history_pet_id_meow-weight-tracker_pets_id_fk",
+          "tableFrom": "meow-weight-tracker_weight_history",
+          "tableTo": "meow-weight-tracker_pets",
+          "columnsFrom": [
+            "pet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "Scheduled",
+        "Completed",
+        "Cancelled"
+      ]
+    },
+    "public.pet_role": {
+      "name": "pet_role",
+      "schema": "public",
+      "values": [
+        "Owner",
+        "Editor",
+        "Viewer"
+      ]
+    },
+    "public.weight_unit": {
+      "name": "weight_unit",
+      "schema": "public",
+      "values": [
+        "kg",
+        "lb"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778736751233,
       "tag": "0010_dry_hitman",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1778741100956,
+      "tag": "0011_flawless_hobgoblin",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1778741100956,
       "tag": "0011_flawless_hobgoblin",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1778741419585,
+      "tag": "0012_nostalgic_rafael_vega",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/_components/bottom-nav.tsx
+++ b/src/app/_components/bottom-nav.tsx
@@ -38,7 +38,7 @@ export function BottomNav() {
     return (
         <nav
             aria-label="Primary"
-            className="fixed inset-x-0 bottom-0 z-40 border-t bg-background pb-[env(safe-area-inset-bottom)] md:hidden"
+            className="fixed inset-x-0 bottom-0 z-40 border-t bg-background pb-[env(safe-area-inset-bottom)] md:hidden print:hidden"
         >
             <ul className="mx-auto grid max-w-md grid-cols-4">
                 {TABS.map((tab) => {

--- a/src/app/_components/topnav.tsx
+++ b/src/app/_components/topnav.tsx
@@ -5,7 +5,7 @@ import { ThemeToggle } from "~/components/theme-toggle";
 
 export function TopNav() {
     return (
-        <nav className="flex w-full items-center justify-between border-b px-4 py-3">
+        <nav className="flex w-full items-center justify-between border-b px-4 py-3 print:hidden">
             <Link href="/" className="text-lg font-semibold">
                 🐾 Meow
             </Link>

--- a/src/app/api/cron/daily-reminders/route.ts
+++ b/src/app/api/cron/daily-reminders/route.ts
@@ -1,11 +1,12 @@
 import { clerkClient } from "@clerk/nextjs/server";
-import { desc, eq, isNull } from "drizzle-orm";
+import { and, desc, eq, gte, isNull, lt } from "drizzle-orm";
 import { Resend } from "resend";
 
 import { env } from "~/env";
 import { db } from "~/server/db";
 import {
     eatingHistory,
+    petAppointments,
     petPeople,
     pets,
     userPreferences,
@@ -14,6 +15,28 @@ import {
 export const dynamic = "force-dynamic";
 
 const HUNGRY_HOURS = 18;
+const APPOINTMENT_LOOKAHEAD_HOURS = 24;
+
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+function formatInTimeZone(date: Date, timeZone: string): string {
+    try {
+        return new Intl.DateTimeFormat("en-US", {
+            dateStyle: "full",
+            timeStyle: "short",
+            timeZone,
+        }).format(date);
+    } catch {
+        return date.toUTCString();
+    }
+}
 
 type Recipient = { email: string; userId: string };
 
@@ -77,13 +100,22 @@ export async function GET(req: Request) {
     const now = Date.now();
     const cutoff = new Date(now - HUNGRY_HOURS * 3_600_000);
 
-    // Users who explicitly turned reminders off. A missing preferences row
-    // means the default (enabled), so we only need the opt-out set.
-    const optedOutRows = await db
-        .select({ userId: userPreferences.userId })
-        .from(userPreferences)
-        .where(eq(userPreferences.dailyRemindersEnabled, false));
-    const optedOut = new Set(optedOutRows.map((r) => r.userId));
+    // One pass over preferences: the opt-out set for gating reminders, and
+    // a timezone lookup so appointment times render in each user's zone. A
+    // missing preferences row means the defaults (enabled, UTC).
+    const prefRows = await db
+        .select({
+            userId: userPreferences.userId,
+            dailyRemindersEnabled: userPreferences.dailyRemindersEnabled,
+            timezone: userPreferences.timezone,
+        })
+        .from(userPreferences);
+    const optedOut = new Set(
+        prefRows.filter((r) => !r.dailyRemindersEnabled).map((r) => r.userId),
+    );
+    const timezoneByUser = new Map(
+        prefRows.map((r) => [r.userId, r.timezone]),
+    );
 
     const allPets = await db
         .select({ id: pets.id, name: pets.name })
@@ -143,5 +175,95 @@ export async function GET(req: Request) {
         summary.push({ petId: pet.id, sent, reason: "hungry" });
     }
 
-    return Response.json({ ranAt: new Date(now).toISOString(), summary });
+    // --- Upcoming appointment reminders ---------------------------------
+    // Scheduled appointments landing within the next lookahead window. The
+    // daily cadence plus a 24h window means each appointment is reminded
+    // about roughly once, the day before it happens.
+    const lookaheadEnd = new Date(
+        now + APPOINTMENT_LOOKAHEAD_HOURS * 3_600_000,
+    );
+    const upcomingAppointments = await db
+        .select({
+            id: petAppointments.id,
+            petId: petAppointments.petId,
+            petName: pets.name,
+            title: petAppointments.title,
+            appointmentType: petAppointments.appointmentType,
+            scheduledFor: petAppointments.scheduledFor,
+            location: petAppointments.location,
+        })
+        .from(petAppointments)
+        .innerJoin(pets, eq(pets.id, petAppointments.petId))
+        .where(
+            and(
+                eq(petAppointments.status, "Scheduled"),
+                isNull(pets.deletedAt),
+                gte(petAppointments.scheduledFor, new Date(now)),
+                lt(petAppointments.scheduledFor, lookaheadEnd),
+            ),
+        );
+
+    const appointmentsByPet = new Map<
+        number,
+        typeof upcomingAppointments
+    >();
+    for (const appt of upcomingAppointments) {
+        const list = appointmentsByPet.get(appt.petId) ?? [];
+        list.push(appt);
+        appointmentsByPet.set(appt.petId, list);
+    }
+
+    const appointmentSummary: {
+        appointmentId: number;
+        petId: number;
+        sent: number;
+    }[] = [];
+    for (const [petId, appts] of appointmentsByPet) {
+        const recipients = (await recipientsForPet(petId)).filter(
+            (r) => !optedOut.has(r.userId),
+        );
+        for (const appt of appts) {
+            let sent = 0;
+            for (const r of recipients) {
+                const when = formatInTimeZone(
+                    appt.scheduledFor,
+                    timezoneByUser.get(r.userId) ?? "UTC",
+                );
+                const locationLine = appt.location
+                    ? `<p>Location: ${escapeHtml(appt.location)}</p>`
+                    : "";
+                try {
+                    await resend.emails.send({
+                        from: env.RESEND_FROM,
+                        to: r.email,
+                        subject: `Upcoming appointment for ${appt.petName}: ${appt.title}`,
+                        html: `<p><strong>${escapeHtml(
+                            appt.petName,
+                        )}</strong> has an upcoming appointment:</p><p><strong>${escapeHtml(
+                            appt.title,
+                        )}</strong> (${escapeHtml(
+                            appt.appointmentType,
+                        )})<br/>${when}</p>${locationLine}<p>View it on the Meow Weight Tracker dashboard.</p>`,
+                    });
+                    sent += 1;
+                } catch (err) {
+                    console.error(
+                        `Resend appointment send failed for ${r.email}`,
+                        err,
+                    );
+                }
+            }
+            appointmentSummary.push({
+                appointmentId: appt.id,
+                petId,
+                sent,
+            });
+        }
+    }
+
+    return Response.json({
+        ranAt: new Date(now).toISOString(),
+        summary,
+        appointmentSummary,
+    });
 }

--- a/src/app/dashboard/_components/dashboard-content.tsx
+++ b/src/app/dashboard/_components/dashboard-content.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { ChevronRight } from "lucide-react";
+import { BarChart3, ChevronRight } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
 import {
@@ -35,7 +35,15 @@ export function DashboardContent({ pets }: { pets: Pet[] }) {
                 selectedId={selectedPet.id}
                 onSelect={setSelectedId}
             />
-            <div className="flex justify-end">
+            <div className="flex justify-end gap-1">
+                {pets.length > 1 && (
+                    <Button asChild variant="ghost" size="sm">
+                        <Link href="/dashboard/compare">
+                            <BarChart3 className="mr-1 h-4 w-4" />
+                            Compare weights
+                        </Link>
+                    </Button>
+                )}
                 <Button asChild variant="ghost" size="sm">
                     <Link href={`/dashboard/pets/${selectedPet.id}`}>
                         {selectedPet.name}&apos;s details

--- a/src/app/dashboard/_components/lazy-charts.tsx
+++ b/src/app/dashboard/_components/lazy-charts.tsx
@@ -41,3 +41,11 @@ export const WeightStatsCard = dynamic(
         })),
     { ssr: false, loading: () => <Skeleton className="h-32 w-full" /> },
 );
+
+export const WeightComparison = dynamic(
+    () =>
+        import("./weight-comparison").then((m) => ({
+            default: m.WeightComparison,
+        })),
+    { ssr: false, loading: () => <Skeleton className="h-96 w-full" /> },
+);

--- a/src/app/dashboard/_components/weight-comparison.tsx
+++ b/src/app/dashboard/_components/weight-comparison.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useState } from "react";
+import { LineChart as LineChartIcon } from "lucide-react";
+import {
+    CartesianGrid,
+    Line,
+    LineChart,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from "recharts";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
+import { Skeleton } from "~/components/ui/skeleton";
+import { useWeightUnit } from "~/hooks/use-weight-unit";
+import { fromKg } from "~/lib/units";
+import { cn } from "~/lib/utils";
+import { api } from "~/trpc/react";
+
+type Range = "30d" | "90d" | "all";
+const RANGES: { value: Range; label: string; days: number | null }[] = [
+    { value: "30d", label: "30d", days: 30 },
+    { value: "90d", label: "90d", days: 90 },
+    { value: "all", label: "All", days: null },
+];
+
+const SERIES_COLORS = [
+    "hsl(220 80% 55%)",
+    "hsl(160 65% 45%)",
+    "hsl(15 80% 50%)",
+    "hsl(265 70% 60%)",
+    "hsl(45 90% 50%)",
+    "hsl(330 70% 55%)",
+];
+
+export function WeightComparison() {
+    const [range, setRange] = useState<Range>("90d");
+    const [hidden, setHidden] = useState<Set<number>>(new Set());
+    const unit = useWeightUnit();
+    const { data, isLoading } = api.weight.getComparison.useQuery();
+
+    function toggle(petId: number) {
+        setHidden((prev) => {
+            const next = new Set(prev);
+            if (next.has(petId)) next.delete(petId);
+            else next.add(petId);
+            return next;
+        });
+    }
+
+    const rangeDays = RANGES.find((r) => r.value === range)?.days ?? null;
+    const cutoffMs =
+        rangeDays === null ? 0 : Date.now() - rangeDays * 86_400_000;
+
+    const series = (data ?? []).map((s, i) => ({
+        ...s,
+        color: SERIES_COLORS[i % SERIES_COLORS.length]!,
+    }));
+    const shownSeries = series.filter((s) => !hidden.has(s.petId));
+
+    const rowMap = new Map<number, Record<string, number>>();
+    for (const s of shownSeries) {
+        for (const pt of s.points) {
+            const t = pt.weighedAt.getTime();
+            if (cutoffMs !== 0 && t < cutoffMs) continue;
+            const row = rowMap.get(t) ?? {};
+            row[`p${s.petId}`] = fromKg(pt.weight, unit);
+            rowMap.set(t, row);
+        }
+    }
+    const chartData = [...rowMap.entries()]
+        .sort((a, b) => a[0] - b[0])
+        .map(([t, values]) => ({ t, ...values }));
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                <div>
+                    <CardTitle className="flex items-center gap-2">
+                        <LineChartIcon className="h-4 w-4" />
+                        Weight comparison
+                    </CardTitle>
+                    <CardDescription>
+                        Every pet&apos;s weight history, overlaid.
+                    </CardDescription>
+                </div>
+                <div className="flex gap-1">
+                    {RANGES.map((r) => (
+                        <Button
+                            key={r.value}
+                            type="button"
+                            size="sm"
+                            variant={r.value === range ? "default" : "outline"}
+                            onClick={() => setRange(r.value)}
+                            className={cn("h-8 px-3 text-xs")}
+                        >
+                            {r.label}
+                        </Button>
+                    ))}
+                </div>
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <Skeleton className="h-72 w-full" />
+                ) : !data || data.length < 2 ? (
+                    <EmptyState
+                        icon={LineChartIcon}
+                        title="Add a second pet to compare"
+                        description="Once you track two or more pets, their weight trends line up here."
+                        className="h-72"
+                    />
+                ) : (
+                    <>
+                        <div className="mb-4 flex flex-wrap gap-1.5">
+                            {series.map((s) => {
+                                const shown = !hidden.has(s.petId);
+                                return (
+                                    <button
+                                        key={s.petId}
+                                        type="button"
+                                        onClick={() => toggle(s.petId)}
+                                        aria-pressed={shown}
+                                        className={cn(
+                                            "flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-opacity",
+                                            shown
+                                                ? "border-transparent bg-muted"
+                                                : "border-input opacity-50",
+                                        )}
+                                    >
+                                        <span
+                                            className="h-2 w-2 rounded-full"
+                                            style={{ backgroundColor: s.color }}
+                                        />
+                                        {s.petName}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                        {chartData.length === 0 ? (
+                            <EmptyState
+                                icon={LineChartIcon}
+                                title="No readings in this range"
+                                description="Try a wider range, or pick at least one pet above."
+                                className="h-64"
+                            />
+                        ) : (
+                            <div
+                                className="h-72 w-full"
+                                role="img"
+                                aria-label={`Weight comparison chart for ${
+                                    shownSeries.length
+                                } ${
+                                    shownSeries.length === 1 ? "pet" : "pets"
+                                }, measured in ${unit}.`}
+                            >
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <LineChart
+                                        accessibilityLayer
+                                        data={chartData}
+                                        margin={{
+                                            top: 8,
+                                            right: 8,
+                                            left: 0,
+                                            bottom: 0,
+                                        }}
+                                    >
+                                        <CartesianGrid
+                                            strokeDasharray="3 3"
+                                            stroke="hsl(var(--border))"
+                                        />
+                                        <XAxis
+                                            dataKey="t"
+                                            type="number"
+                                            scale="time"
+                                            domain={["dataMin", "dataMax"]}
+                                            tickFormatter={(t: number) =>
+                                                new Date(
+                                                    t,
+                                                ).toLocaleDateString(
+                                                    undefined,
+                                                    {
+                                                        month: "short",
+                                                        day: "numeric",
+                                                    },
+                                                )
+                                            }
+                                            tick={{ fontSize: 11 }}
+                                        />
+                                        <YAxis
+                                            domain={["auto", "auto"]}
+                                            tick={{ fontSize: 11 }}
+                                            width={36}
+                                        />
+                                        <Tooltip
+                                            labelFormatter={(t) =>
+                                                new Date(
+                                                    Number(t),
+                                                ).toLocaleString()
+                                            }
+                                            formatter={(value, name) => [
+                                                `${Number(value).toFixed(
+                                                    2,
+                                                )} ${unit}`,
+                                                String(name),
+                                            ]}
+                                        />
+                                        {shownSeries.map((s) => (
+                                            <Line
+                                                key={s.petId}
+                                                type="monotone"
+                                                dataKey={`p${s.petId}`}
+                                                name={s.petName}
+                                                stroke={s.color}
+                                                strokeWidth={2}
+                                                dot={{ r: 2 }}
+                                                activeDot={{ r: 4 }}
+                                                connectNulls
+                                            />
+                                        ))}
+                                    </LineChart>
+                                </ResponsiveContainer>
+                            </div>
+                        )}
+                    </>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/compare/page.tsx
+++ b/src/app/dashboard/compare/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import { WeightComparison } from "~/app/dashboard/_components/lazy-charts";
+
+export default function ComparePage() {
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center justify-between">
+                <Button asChild variant="ghost" size="sm" className="-ml-2">
+                    <Link href="/dashboard">
+                        <ChevronLeft className="mr-1 h-4 w-4" />
+                        Dashboard
+                    </Link>
+                </Button>
+            </div>
+            <div>
+                <h1 className="text-lg font-semibold">Compare weights</h1>
+                <p className="text-sm text-muted-foreground">
+                    Overlay every pet&apos;s weight history on one chart.
+                </p>
+            </div>
+            <WeightComparison />
+        </div>
+    );
+}

--- a/src/app/dashboard/pets/[id]/_components/appointments-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/appointments-card.tsx
@@ -1,0 +1,488 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import {
+    Ban,
+    CalendarClock,
+    CheckCircle2,
+    MapPin,
+    Pencil,
+    Plus,
+    RotateCcw,
+    Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "~/components/ui/dialog";
+import { EmptyState } from "~/components/ui/empty-state";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { api, type RouterOutputs } from "~/trpc/react";
+
+type Appointment = RouterOutputs["appointments"]["list"][number];
+
+const APPOINTMENT_TYPES = [
+    "Vet visit",
+    "Vaccination",
+    "Grooming",
+    "Dental cleaning",
+    "Checkup",
+    "Surgery",
+    "Other",
+];
+
+// Convert a Date to the `YYYY-MM-DDTHH:mm` string a datetime-local input
+// expects, in the viewer's local timezone.
+function toLocalInput(d: Date): string {
+    const offsetMs = d.getTimezoneOffset() * 60_000;
+    return new Date(d.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+export function AppointmentsCard({
+    petId,
+    canEdit,
+}: {
+    petId: number;
+    canEdit: boolean;
+}) {
+    const { data, isLoading } = api.appointments.list.useQuery({ petId });
+
+    const now = Date.now();
+    const all = data ?? [];
+    const upcoming = all
+        .filter(
+            (a) => a.status === "Scheduled" && a.scheduledFor.getTime() >= now,
+        )
+        .sort((a, b) => a.scheduledFor.getTime() - b.scheduledFor.getTime());
+    const past = all.filter(
+        (a) => !(a.status === "Scheduled" && a.scheduledFor.getTime() >= now),
+    );
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                <div>
+                    <CardTitle className="flex items-center gap-2">
+                        <CalendarClock className="h-4 w-4" />
+                        Appointments
+                    </CardTitle>
+                    <CardDescription>
+                        Upcoming vet &amp; grooming visits.
+                    </CardDescription>
+                </div>
+                {canEdit && <AppointmentFormDialog petId={petId} />}
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <p className="text-sm text-muted-foreground">Loading…</p>
+                ) : all.length === 0 ? (
+                    <EmptyState
+                        icon={CalendarClock}
+                        title="No appointments yet"
+                        description="Schedule vet visits, grooming, and checkups."
+                    />
+                ) : (
+                    <div className="space-y-5">
+                        {upcoming.length > 0 && (
+                            <div>
+                                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                    Upcoming
+                                </h3>
+                                <ul className="divide-y">
+                                    {upcoming.map((a) => (
+                                        <AppointmentRow
+                                            key={a.id}
+                                            appointment={a}
+                                            canEdit={canEdit}
+                                        />
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+                        {past.length > 0 && (
+                            <div>
+                                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                    Past &amp; closed
+                                </h3>
+                                <ul className="divide-y">
+                                    {past.map((a) => (
+                                        <AppointmentRow
+                                            key={a.id}
+                                            appointment={a}
+                                            canEdit={canEdit}
+                                        />
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+function AppointmentRow({
+    appointment,
+    canEdit,
+}: {
+    appointment: Appointment;
+    canEdit: boolean;
+}) {
+    const utils = api.useUtils();
+    const petId = appointment.petId;
+
+    const setStatus = api.appointments.setStatus.useMutation({
+        onSuccess: async () => {
+            await utils.appointments.list.invalidate({ petId });
+        },
+        onError: (err) => toast.error(err.message),
+    });
+    const remove = api.appointments.deleteEntry.useMutation({
+        onSuccess: async () => {
+            await utils.appointments.list.invalidate({ petId });
+            toast.success("Appointment deleted");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+
+    const busy = setStatus.isPending || remove.isPending;
+    const isScheduled = appointment.status === "Scheduled";
+    const isCancelled = appointment.status === "Cancelled";
+    const isOverdue =
+        isScheduled && appointment.scheduledFor.getTime() < Date.now();
+
+    return (
+        <li className="flex items-start justify-between gap-3 py-3 text-sm">
+            <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-baseline gap-2">
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">
+                        {appointment.appointmentType}
+                    </span>
+                    <span
+                        className={
+                            isCancelled
+                                ? "font-medium text-muted-foreground line-through"
+                                : "font-medium"
+                        }
+                    >
+                        {appointment.title}
+                    </span>
+                    {appointment.status === "Completed" && (
+                        <span className="text-[10px] font-medium uppercase text-green-600 dark:text-green-500">
+                            Completed
+                        </span>
+                    )}
+                    {isCancelled && (
+                        <span className="text-[10px] font-medium uppercase text-muted-foreground">
+                            Cancelled
+                        </span>
+                    )}
+                    {isOverdue && (
+                        <span className="text-[10px] font-medium uppercase text-amber-600 dark:text-amber-500">
+                            Overdue
+                        </span>
+                    )}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                    {appointment.scheduledFor.toLocaleString()}
+                </div>
+                {appointment.location && (
+                    <div className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+                        <MapPin className="h-3 w-3 shrink-0" />
+                        <span className="min-w-0 truncate">
+                            {appointment.location}
+                        </span>
+                    </div>
+                )}
+                {appointment.notes && (
+                    <p className="mt-1 text-xs">{appointment.notes}</p>
+                )}
+            </div>
+            {canEdit && (
+                <div className="flex shrink-0 items-center gap-0.5">
+                    {isScheduled ? (
+                        <>
+                            <Button
+                                type="button"
+                                size="icon"
+                                variant="ghost"
+                                disabled={busy}
+                                aria-label="Mark as completed"
+                                title="Mark as completed"
+                                onClick={() =>
+                                    setStatus.mutate({
+                                        appointmentId: appointment.id,
+                                        status: "Completed",
+                                    })
+                                }
+                            >
+                                <CheckCircle2 className="h-3.5 w-3.5" />
+                            </Button>
+                            <Button
+                                type="button"
+                                size="icon"
+                                variant="ghost"
+                                disabled={busy}
+                                aria-label="Cancel appointment"
+                                title="Cancel appointment"
+                                onClick={() =>
+                                    setStatus.mutate({
+                                        appointmentId: appointment.id,
+                                        status: "Cancelled",
+                                    })
+                                }
+                            >
+                                <Ban className="h-3.5 w-3.5" />
+                            </Button>
+                        </>
+                    ) : (
+                        <Button
+                            type="button"
+                            size="icon"
+                            variant="ghost"
+                            disabled={busy}
+                            aria-label="Reopen appointment"
+                            title="Reopen appointment"
+                            onClick={() =>
+                                setStatus.mutate({
+                                    appointmentId: appointment.id,
+                                    status: "Scheduled",
+                                })
+                            }
+                        >
+                            <RotateCcw className="h-3.5 w-3.5" />
+                        </Button>
+                    )}
+                    <AppointmentFormDialog
+                        petId={petId}
+                        appointment={appointment}
+                    />
+                    <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        disabled={busy}
+                        aria-label="Delete appointment"
+                        title="Delete appointment"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => {
+                            if (!confirm("Delete this appointment?")) return;
+                            remove.mutate({ appointmentId: appointment.id });
+                        }}
+                    >
+                        <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                </div>
+            )}
+        </li>
+    );
+}
+
+function AppointmentFormDialog({
+    petId,
+    appointment,
+}: {
+    petId: number;
+    appointment?: Appointment;
+}) {
+    const isEdit = appointment !== undefined;
+    const utils = api.useUtils();
+    const [open, setOpen] = useState(false);
+    const [title, setTitle] = useState(appointment?.title ?? "");
+    const [type, setType] = useState(
+        appointment?.appointmentType ?? "Vet visit",
+    );
+    const [scheduledFor, setScheduledFor] = useState(
+        appointment ? toLocalInput(appointment.scheduledFor) : "",
+    );
+    const [location, setLocation] = useState(appointment?.location ?? "");
+    const [notes, setNotes] = useState(appointment?.notes ?? "");
+
+    const create = api.appointments.create.useMutation({
+        onSuccess: async () => {
+            await utils.appointments.list.invalidate({ petId });
+            setOpen(false);
+            setTitle("");
+            setType("Vet visit");
+            setScheduledFor("");
+            setLocation("");
+            setNotes("");
+            toast.success("Appointment scheduled");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+    const update = api.appointments.updateEntry.useMutation({
+        onSuccess: async () => {
+            await utils.appointments.list.invalidate({ petId });
+            setOpen(false);
+            toast.success("Appointment updated");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+    const pending = create.isPending || update.isPending;
+
+    // Re-seed the form from the latest data each time an edit dialog opens.
+    function handleOpenChange(next: boolean) {
+        if (next && appointment) {
+            setTitle(appointment.title);
+            setType(appointment.appointmentType);
+            setScheduledFor(toLocalInput(appointment.scheduledFor));
+            setLocation(appointment.location ?? "");
+            setNotes(appointment.notes ?? "");
+        }
+        setOpen(next);
+    }
+
+    function onSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!scheduledFor) {
+            toast.error("Pick a date and time");
+            return;
+        }
+        const when = new Date(scheduledFor);
+        if (appointment) {
+            update.mutate({
+                appointmentId: appointment.id,
+                title: title.trim(),
+                appointmentType: type,
+                scheduledFor: when,
+                location: location.trim() ? location.trim() : null,
+                notes: notes.trim() ? notes.trim() : null,
+            });
+        } else {
+            create.mutate({
+                petId,
+                title: title.trim(),
+                appointmentType: type,
+                scheduledFor: when,
+                ...(location.trim() ? { location: location.trim() } : {}),
+                ...(notes.trim() ? { notes: notes.trim() } : {}),
+            });
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogTrigger asChild>
+                {isEdit ? (
+                    <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        aria-label="Edit appointment"
+                        title="Edit appointment"
+                    >
+                        <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                ) : (
+                    <Button type="button" size="sm" variant="outline">
+                        <Plus className="mr-1 h-3.5 w-3.5" />
+                        Add appointment
+                    </Button>
+                )}
+            </DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>
+                        {isEdit ? "Edit appointment" : "Add appointment"}
+                    </DialogTitle>
+                </DialogHeader>
+                <form onSubmit={onSubmit} className="space-y-3">
+                    <div className="space-y-1">
+                        <Label htmlFor="ap-title">Title</Label>
+                        <Input
+                            id="ap-title"
+                            required
+                            value={title}
+                            onChange={(e) => setTitle(e.target.value)}
+                            placeholder="Annual checkup"
+                        />
+                    </div>
+                    <div className="space-y-1">
+                        <Label htmlFor="ap-type">Type</Label>
+                        <select
+                            id="ap-type"
+                            value={type}
+                            onChange={(e) => setType(e.target.value)}
+                            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        >
+                            {APPOINTMENT_TYPES.map((t) => (
+                                <option key={t} value={t}>
+                                    {t}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <div className="space-y-1">
+                        <Label htmlFor="ap-when">When</Label>
+                        <Input
+                            id="ap-when"
+                            type="datetime-local"
+                            required
+                            value={scheduledFor}
+                            onChange={(e) => setScheduledFor(e.target.value)}
+                        />
+                    </div>
+                    <div className="space-y-1">
+                        <Label htmlFor="ap-location">Location</Label>
+                        <Input
+                            id="ap-location"
+                            value={location}
+                            onChange={(e) => setLocation(e.target.value)}
+                            placeholder="Downtown Vet Clinic"
+                            maxLength={256}
+                        />
+                    </div>
+                    <div className="space-y-1">
+                        <Label htmlFor="ap-notes">Notes</Label>
+                        <Input
+                            id="ap-notes"
+                            value={notes}
+                            onChange={(e) => setNotes(e.target.value)}
+                            placeholder="Bring vaccination records"
+                            maxLength={2048}
+                        />
+                    </div>
+                    {(create.error ?? update.error) && (
+                        <p className="text-sm text-destructive">
+                            {(create.error ?? update.error)?.message}
+                        </p>
+                    )}
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => setOpen(false)}
+                            disabled={pending}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={pending}>
+                            {pending
+                                ? "Saving…"
+                                : isEdit
+                                  ? "Save"
+                                  : "Schedule"}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/app/dashboard/pets/[id]/_components/photo-gallery-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/photo-gallery-card.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { ImagePlus, Images, Star, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "~/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "~/components/ui/dialog";
+import { EmptyState } from "~/components/ui/empty-state";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { api } from "~/trpc/react";
+
+export function PhotoGalleryCard({
+    petId,
+    canEdit,
+    primaryUrl,
+}: {
+    petId: number;
+    canEdit: boolean;
+    primaryUrl: string | null;
+}) {
+    const router = useRouter();
+    const utils = api.useUtils();
+    const { data, isLoading } = api.photos.list.useQuery({ petId });
+
+    const [open, setOpen] = useState(false);
+    const [file, setFile] = useState<File | null>(null);
+    const [caption, setCaption] = useState("");
+    const [takenAt, setTakenAt] = useState("");
+    const [uploading, setUploading] = useState(false);
+
+    const add = api.photos.add.useMutation({
+        onSuccess: async () => {
+            await utils.photos.list.invalidate({ petId });
+            setOpen(false);
+            setFile(null);
+            setCaption("");
+            setTakenAt("");
+            toast.success("Photo added");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+    const setPrimary = api.photos.setPrimary.useMutation({
+        onSuccess: async () => {
+            await utils.photos.list.invalidate({ petId });
+            router.refresh();
+            toast.success("Primary photo updated");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+    const remove = api.photos.remove.useMutation({
+        onSuccess: async () => {
+            await utils.photos.list.invalidate({ petId });
+            router.refresh();
+            toast.success("Photo deleted");
+        },
+        onError: (err) => toast.error(err.message),
+    });
+
+    async function onSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!file) {
+            toast.error("Choose an image first");
+            return;
+        }
+        setUploading(true);
+        try {
+            const form = new FormData();
+            form.set("file", file);
+            form.set("petId", String(petId));
+            const res = await fetch(`/api/pets/${petId}/photo`, {
+                method: "POST",
+                body: form,
+            });
+            if (!res.ok) {
+                toast.error((await res.text()) || "Upload failed");
+                return;
+            }
+            const uploaded = (await res.json()) as { url: string };
+            add.mutate({
+                petId,
+                url: uploaded.url,
+                ...(caption.trim() ? { caption: caption.trim() } : {}),
+                ...(takenAt ? { takenAt: new Date(takenAt) } : {}),
+            });
+        } catch (err) {
+            toast.error(err instanceof Error ? err.message : "Upload failed");
+        } finally {
+            setUploading(false);
+        }
+    }
+
+    const busy = uploading || add.isPending;
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-start justify-between space-y-0">
+                <div>
+                    <CardTitle className="flex items-center gap-2">
+                        <Images className="h-4 w-4" />
+                        Photos
+                    </CardTitle>
+                    <CardDescription>
+                        A visual history, newest first.
+                    </CardDescription>
+                </div>
+                {canEdit && (
+                    <Dialog open={open} onOpenChange={setOpen}>
+                        <DialogTrigger asChild>
+                            <Button type="button" size="sm" variant="outline">
+                                <ImagePlus className="mr-1 h-3.5 w-3.5" />
+                                Add photo
+                            </Button>
+                        </DialogTrigger>
+                        <DialogContent>
+                            <DialogHeader>
+                                <DialogTitle>Add photo</DialogTitle>
+                            </DialogHeader>
+                            <form onSubmit={onSubmit} className="space-y-3">
+                                <div className="space-y-1">
+                                    <Label htmlFor="pg-file">Image</Label>
+                                    <input
+                                        id="pg-file"
+                                        type="file"
+                                        accept="image/jpeg,image/png,image/webp,image/gif"
+                                        onChange={(e) =>
+                                            setFile(
+                                                e.target.files?.[0] ?? null,
+                                            )
+                                        }
+                                        className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm file:mr-3 file:rounded file:border-0 file:bg-muted file:px-2 file:py-1 file:text-sm"
+                                    />
+                                </div>
+                                <div className="space-y-1">
+                                    <Label htmlFor="pg-caption">Caption</Label>
+                                    <Input
+                                        id="pg-caption"
+                                        value={caption}
+                                        onChange={(e) =>
+                                            setCaption(e.target.value)
+                                        }
+                                        placeholder="Napping in the sun"
+                                        maxLength={256}
+                                    />
+                                </div>
+                                <div className="space-y-1">
+                                    <Label htmlFor="pg-when">Taken on</Label>
+                                    <Input
+                                        id="pg-when"
+                                        type="datetime-local"
+                                        value={takenAt}
+                                        onChange={(e) =>
+                                            setTakenAt(e.target.value)
+                                        }
+                                        max={new Date()
+                                            .toISOString()
+                                            .slice(0, 16)}
+                                    />
+                                </div>
+                                {add.error && (
+                                    <p className="text-sm text-destructive">
+                                        {add.error.message}
+                                    </p>
+                                )}
+                                <DialogFooter>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={() => setOpen(false)}
+                                        disabled={busy}
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button type="submit" disabled={busy}>
+                                        {busy ? "Saving…" : "Save"}
+                                    </Button>
+                                </DialogFooter>
+                            </form>
+                        </DialogContent>
+                    </Dialog>
+                )}
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <p className="text-sm text-muted-foreground">Loading…</p>
+                ) : !data || data.length === 0 ? (
+                    <EmptyState
+                        icon={Images}
+                        title="No photos yet"
+                        description="Upload photos to build a visual history of your pet."
+                    />
+                ) : (
+                    <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                        {data.map((photo) => {
+                            const isPrimary =
+                                primaryUrl !== null &&
+                                photo.url === primaryUrl;
+                            return (
+                                <li
+                                    key={photo.id}
+                                    className="group relative overflow-hidden rounded-lg border"
+                                >
+                                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                                    <img
+                                        src={photo.url}
+                                        alt={photo.caption ?? ""}
+                                        className="aspect-square w-full object-cover"
+                                    />
+                                    {isPrimary && (
+                                        <span className="absolute left-1.5 top-1.5 flex items-center gap-1 rounded bg-background/90 px-1.5 py-0.5 text-[10px] font-medium">
+                                            <Star className="h-3 w-3 fill-current" />
+                                            Primary
+                                        </span>
+                                    )}
+                                    {canEdit && (
+                                        <div className="absolute inset-x-0 bottom-0 flex justify-end gap-1 bg-gradient-to-t from-black/60 to-transparent p-1.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+                                            {!isPrimary && (
+                                                <Button
+                                                    type="button"
+                                                    size="icon"
+                                                    variant="secondary"
+                                                    className="h-7 w-7"
+                                                    disabled={
+                                                        setPrimary.isPending
+                                                    }
+                                                    aria-label="Set as primary photo"
+                                                    onClick={() =>
+                                                        setPrimary.mutate({
+                                                            photoId: photo.id,
+                                                        })
+                                                    }
+                                                >
+                                                    <Star className="h-3.5 w-3.5" />
+                                                </Button>
+                                            )}
+                                            <Button
+                                                type="button"
+                                                size="icon"
+                                                variant="secondary"
+                                                className="h-7 w-7 text-destructive"
+                                                disabled={remove.isPending}
+                                                aria-label="Delete photo"
+                                                onClick={() => {
+                                                    if (
+                                                        !confirm(
+                                                            "Delete this photo?",
+                                                        )
+                                                    )
+                                                        return;
+                                                    remove.mutate({
+                                                        photoId: photo.id,
+                                                    });
+                                                }}
+                                            >
+                                                <Trash2 className="h-3.5 w-3.5" />
+                                            </Button>
+                                        </div>
+                                    )}
+                                    <div className="space-y-0.5 p-2">
+                                        {photo.caption && (
+                                            <p className="truncate text-xs font-medium">
+                                                {photo.caption}
+                                            </p>
+                                        )}
+                                        <p className="text-[10px] text-muted-foreground">
+                                            {photo.takenAt.toLocaleDateString()}
+                                        </p>
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/pets/[id]/_components/timeline-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/timeline-card.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import {
+    Activity,
+    HeartPulse,
+    History,
+    Scale,
+    StickyNote,
+    UtensilsCrossed,
+    type LucideIcon,
+} from "lucide-react";
+
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "~/components/ui/card";
+import { EmptyState } from "~/components/ui/empty-state";
+import { useWeightUnit } from "~/hooks/use-weight-unit";
+import { formatWeight } from "~/lib/units";
+import { api, type RouterOutputs } from "~/trpc/react";
+
+type TimelineItem = RouterOutputs["timeline"]["get"][number];
+type WeightUnit = ReturnType<typeof useWeightUnit>;
+
+function describe(
+    item: TimelineItem,
+    unit: WeightUnit,
+): {
+    icon: LucideIcon;
+    label: string;
+    primary: string;
+    detail: string | null;
+} {
+    switch (item.kind) {
+        case "weight":
+            return {
+                icon: Scale,
+                label: "Weight",
+                primary: `Weighed ${formatWeight(item.weightKg, unit)}`,
+                detail: null,
+            };
+        case "feeding":
+            return {
+                icon: UtensilsCrossed,
+                label: "Feeding",
+                primary: `Fed ${item.quantityGrams} g of ${item.foodName}`,
+                detail: null,
+            };
+        case "activity":
+            return {
+                icon: Activity,
+                label: "Activity",
+                primary: `${item.activityType} — ${item.durationMinutes} min`,
+                detail: item.notes,
+            };
+        case "health":
+            return {
+                icon: HeartPulse,
+                label: item.eventType,
+                primary: item.title,
+                detail: item.notes,
+            };
+        case "note":
+            return {
+                icon: StickyNote,
+                label: "Note",
+                primary: item.body,
+                detail: null,
+            };
+    }
+}
+
+export function TimelineCard({ petId }: { petId: number }) {
+    const { data, isLoading } = api.timeline.get.useQuery({ petId });
+    const unit = useWeightUnit();
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                    <History className="h-4 w-4" />
+                    Timeline
+                </CardTitle>
+                <CardDescription>
+                    Every logged event, newest first.
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                {isLoading ? (
+                    <p className="text-sm text-muted-foreground">Loading…</p>
+                ) : !data || data.length === 0 ? (
+                    <EmptyState
+                        icon={History}
+                        title="Nothing logged yet"
+                        description="Weigh-ins, feedings, activity, health events, and notes all show up here."
+                    />
+                ) : (
+                    <ul className="space-y-3">
+                        {data.map((item) => {
+                            const {
+                                icon: Icon,
+                                label,
+                                primary,
+                                detail,
+                            } = describe(item, unit);
+                            return (
+                                <li
+                                    key={`${item.kind}-${item.id}`}
+                                    className="flex gap-3 text-sm"
+                                >
+                                    <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted">
+                                        <Icon className="h-3.5 w-3.5" />
+                                    </div>
+                                    <div className="min-w-0 flex-1">
+                                        <div className="flex flex-wrap items-baseline gap-x-2">
+                                            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">
+                                                {label}
+                                            </span>
+                                            <span className="text-xs text-muted-foreground">
+                                                {item.occurredAt.toLocaleString()}
+                                            </span>
+                                        </div>
+                                        <p className="mt-0.5 break-words font-medium">
+                                            {primary}
+                                        </p>
+                                        {detail && (
+                                            <p className="mt-0.5 break-words text-xs text-muted-foreground">
+                                                {detail}
+                                            </p>
+                                        )}
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/app/dashboard/pets/[id]/_components/timeline-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/timeline-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
     Activity,
     HeartPulse,
@@ -10,6 +11,7 @@ import {
     type LucideIcon,
 } from "lucide-react";
 
+import { Button } from "~/components/ui/button";
 import {
     Card,
     CardContent,
@@ -18,12 +20,31 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { EmptyState } from "~/components/ui/empty-state";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
 import { useWeightUnit } from "~/hooks/use-weight-unit";
 import { formatWeight } from "~/lib/units";
 import { api, type RouterOutputs } from "~/trpc/react";
 
 type TimelineItem = RouterOutputs["timeline"]["get"][number];
+type TimelineKind = TimelineItem["kind"];
 type WeightUnit = ReturnType<typeof useWeightUnit>;
+
+const KINDS: { key: TimelineKind; label: string }[] = [
+    { key: "weight", label: "Weight" },
+    { key: "feeding", label: "Feeding" },
+    { key: "activity", label: "Activity" },
+    { key: "health", label: "Health" },
+    { key: "note", label: "Note" },
+];
+
+const ALL_KINDS_ON: Record<TimelineKind, boolean> = {
+    weight: true,
+    feeding: true,
+    activity: true,
+    health: true,
+    note: true,
+};
 
 function describe(
     item: TimelineItem,
@@ -77,6 +98,48 @@ export function TimelineCard({ petId }: { petId: number }) {
     const { data, isLoading } = api.timeline.get.useQuery({ petId });
     const unit = useWeightUnit();
 
+    const [query, setQuery] = useState("");
+    const [fromDate, setFromDate] = useState("");
+    const [toDate, setToDate] = useState("");
+    const [kindFilters, setKindFilters] =
+        useState<Record<TimelineKind, boolean>>(ALL_KINDS_ON);
+
+    const anyFilterActive =
+        query.trim() !== "" ||
+        fromDate !== "" ||
+        toDate !== "" ||
+        KINDS.some((k) => !kindFilters[k.key]);
+
+    function clearFilters() {
+        setQuery("");
+        setFromDate("");
+        setToDate("");
+        setKindFilters(ALL_KINDS_ON);
+    }
+
+    const q = query.trim().toLowerCase();
+    const fromTime = fromDate ? new Date(`${fromDate}T00:00:00`).getTime() : null;
+    const toTime = toDate
+        ? new Date(`${toDate}T23:59:59.999`).getTime()
+        : null;
+
+    const described = (data ?? []).map((item) => ({
+        item,
+        ...describe(item, unit),
+    }));
+    const filtered = described.filter(({ item, label, primary, detail }) => {
+        if (!kindFilters[item.kind]) return false;
+        const t = item.occurredAt.getTime();
+        if (fromTime !== null && t < fromTime) return false;
+        if (toTime !== null && t > toTime) return false;
+        if (q) {
+            const haystack =
+                `${label} ${primary} ${detail ?? ""}`.toLowerCase();
+            if (!haystack.includes(q)) return false;
+        }
+        return true;
+    });
+
     return (
         <Card>
             <CardHeader>
@@ -98,44 +161,137 @@ export function TimelineCard({ petId }: { petId: number }) {
                         description="Weigh-ins, feedings, activity, health events, and notes all show up here."
                     />
                 ) : (
-                    <ul className="space-y-3">
-                        {data.map((item) => {
-                            const {
-                                icon: Icon,
-                                label,
-                                primary,
-                                detail,
-                            } = describe(item, unit);
-                            return (
-                                <li
-                                    key={`${item.kind}-${item.id}`}
-                                    className="flex gap-3 text-sm"
-                                >
-                                    <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted">
-                                        <Icon className="h-3.5 w-3.5" />
-                                    </div>
-                                    <div className="min-w-0 flex-1">
-                                        <div className="flex flex-wrap items-baseline gap-x-2">
-                                            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">
-                                                {label}
-                                            </span>
-                                            <span className="text-xs text-muted-foreground">
-                                                {item.occurredAt.toLocaleString()}
-                                            </span>
-                                        </div>
-                                        <p className="mt-0.5 break-words font-medium">
-                                            {primary}
-                                        </p>
-                                        {detail && (
-                                            <p className="mt-0.5 break-words text-xs text-muted-foreground">
-                                                {detail}
-                                            </p>
-                                        )}
-                                    </div>
-                                </li>
-                            );
-                        })}
-                    </ul>
+                    <>
+                        <div className="mb-4 space-y-2">
+                            <Input
+                                value={query}
+                                onChange={(e) => setQuery(e.target.value)}
+                                placeholder="Search timeline…"
+                                aria-label="Search timeline"
+                            />
+                            <div className="flex flex-wrap gap-1.5">
+                                {KINDS.map((k) => (
+                                    <Button
+                                        key={k.key}
+                                        type="button"
+                                        size="sm"
+                                        variant={
+                                            kindFilters[k.key]
+                                                ? "secondary"
+                                                : "outline"
+                                        }
+                                        aria-pressed={kindFilters[k.key]}
+                                        onClick={() =>
+                                            setKindFilters((prev) => ({
+                                                ...prev,
+                                                [k.key]: !prev[k.key],
+                                            }))
+                                        }
+                                    >
+                                        {k.label}
+                                    </Button>
+                                ))}
+                            </div>
+                            <div className="grid grid-cols-2 gap-2">
+                                <div className="space-y-1">
+                                    <Label
+                                        htmlFor="tl-from"
+                                        className="text-xs"
+                                    >
+                                        From
+                                    </Label>
+                                    <Input
+                                        id="tl-from"
+                                        type="date"
+                                        value={fromDate}
+                                        max={toDate || undefined}
+                                        onChange={(e) =>
+                                            setFromDate(e.target.value)
+                                        }
+                                    />
+                                </div>
+                                <div className="space-y-1">
+                                    <Label
+                                        htmlFor="tl-to"
+                                        className="text-xs"
+                                    >
+                                        To
+                                    </Label>
+                                    <Input
+                                        id="tl-to"
+                                        type="date"
+                                        value={toDate}
+                                        min={fromDate || undefined}
+                                        onChange={(e) =>
+                                            setToDate(e.target.value)
+                                        }
+                                    />
+                                </div>
+                            </div>
+                            {anyFilterActive && (
+                                <div className="flex items-center justify-between">
+                                    <p className="text-xs text-muted-foreground">
+                                        Showing {filtered.length} of{" "}
+                                        {data.length}
+                                    </p>
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        variant="ghost"
+                                        onClick={clearFilters}
+                                    >
+                                        Clear filters
+                                    </Button>
+                                </div>
+                            )}
+                        </div>
+                        {filtered.length === 0 ? (
+                            <EmptyState
+                                icon={History}
+                                title="No matching events"
+                                description="Try a different search or widen the filters."
+                            />
+                        ) : (
+                            <ul className="space-y-3">
+                                {filtered.map(
+                                    ({
+                                        item,
+                                        icon: Icon,
+                                        label,
+                                        primary,
+                                        detail,
+                                    }) => (
+                                        <li
+                                            key={`${item.kind}-${item.id}`}
+                                            className="flex gap-3 text-sm"
+                                        >
+                                            <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted">
+                                                <Icon className="h-3.5 w-3.5" />
+                                            </div>
+                                            <div className="min-w-0 flex-1">
+                                                <div className="flex flex-wrap items-baseline gap-x-2">
+                                                    <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">
+                                                        {label}
+                                                    </span>
+                                                    <span className="text-xs text-muted-foreground">
+                                                        {item.occurredAt.toLocaleString()}
+                                                    </span>
+                                                </div>
+                                                <p className="mt-0.5 break-words font-medium">
+                                                    {primary}
+                                                </p>
+                                                {detail && (
+                                                    <p className="mt-0.5 break-words text-xs text-muted-foreground">
+                                                        {detail}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        </li>
+                                    ),
+                                )}
+                            </ul>
+                        )}
+                    </>
                 )}
             </CardContent>
         </Card>

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ChevronLeft, Users } from "lucide-react";
+import { ChevronLeft, FileText, Users } from "lucide-react";
 import { TRPCError } from "@trpc/server";
 
 import { Button } from "~/components/ui/button";
@@ -51,12 +51,20 @@ export default async function PetDetailPage({
                         Dashboard
                     </Link>
                 </Button>
-                <Button asChild variant="outline" size="sm">
-                    <Link href={`/dashboard/pets/${pet.id}/people`}>
-                        <Users className="mr-1 h-3.5 w-3.5" />
-                        People
-                    </Link>
-                </Button>
+                <div className="flex gap-2">
+                    <Button asChild variant="outline" size="sm">
+                        <Link href={`/dashboard/pets/${pet.id}/report`}>
+                            <FileText className="mr-1 h-3.5 w-3.5" />
+                            Report
+                        </Link>
+                    </Button>
+                    <Button asChild variant="outline" size="sm">
+                        <Link href={`/dashboard/pets/${pet.id}/people`}>
+                            <Users className="mr-1 h-3.5 w-3.5" />
+                            People
+                        </Link>
+                    </Button>
+                </div>
             </div>
             <PetAlerts petId={pet.id} petName={pet.name} />
             <PetEditCard pet={pet} />

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -5,6 +5,7 @@ import { TRPCError } from "@trpc/server";
 
 import { Button } from "~/components/ui/button";
 import { PetEditCard } from "~/app/dashboard/pets/[id]/_components/pet-edit-card";
+import { PhotoGalleryCard } from "~/app/dashboard/pets/[id]/_components/photo-gallery-card";
 import { FeedingHistoryList } from "~/app/dashboard/pets/[id]/_components/feeding-history-list";
 import { WeightHistoryList } from "~/app/dashboard/pets/[id]/_components/weight-history-list";
 import { ExportCard } from "~/app/dashboard/pets/[id]/_components/export-card";
@@ -57,6 +58,11 @@ export default async function PetDetailPage({
             </div>
             <PetAlerts petId={pet.id} petName={pet.name} />
             <PetEditCard pet={pet} />
+            <PhotoGalleryCard
+                petId={pet.id}
+                canEdit={pet.role !== "Viewer"}
+                primaryUrl={pet.photoUrl}
+            />
             <WeightStatsCard
                 petId={pet.id}
                 petName={pet.name}

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -11,6 +11,7 @@ import { WeightHistoryList } from "~/app/dashboard/pets/[id]/_components/weight-
 import { ExportCard } from "~/app/dashboard/pets/[id]/_components/export-card";
 import { FeedingHeatmapCard } from "~/app/dashboard/pets/[id]/_components/feeding-heatmap-card";
 import { HealthEventsCard } from "~/app/dashboard/pets/[id]/_components/health-events-card";
+import { AppointmentsCard } from "~/app/dashboard/pets/[id]/_components/appointments-card";
 import { MedsCard } from "~/app/dashboard/pets/[id]/_components/meds-card";
 import { NotesCard } from "~/app/dashboard/pets/[id]/_components/notes-card";
 import { ImportWeightCard } from "~/app/dashboard/pets/[id]/_components/import-weight-card";
@@ -77,6 +78,7 @@ export default async function PetDetailPage({
             <FeedingHeatmapCard petId={pet.id} />
             <FeedingHistoryList petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <HealthEventsCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
+            <AppointmentsCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <MedsCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <NotesCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <ImportWeightCard

--- a/src/app/dashboard/pets/[id]/page.tsx
+++ b/src/app/dashboard/pets/[id]/page.tsx
@@ -14,6 +14,7 @@ import { HealthEventsCard } from "~/app/dashboard/pets/[id]/_components/health-e
 import { AppointmentsCard } from "~/app/dashboard/pets/[id]/_components/appointments-card";
 import { MedsCard } from "~/app/dashboard/pets/[id]/_components/meds-card";
 import { NotesCard } from "~/app/dashboard/pets/[id]/_components/notes-card";
+import { TimelineCard } from "~/app/dashboard/pets/[id]/_components/timeline-card";
 import { ImportWeightCard } from "~/app/dashboard/pets/[id]/_components/import-weight-card";
 import { DeletePetCard } from "~/app/dashboard/pets/[id]/_components/delete-pet-card";
 import { PetAlerts } from "~/app/dashboard/_components/pet-alerts";
@@ -81,6 +82,7 @@ export default async function PetDetailPage({
             <AppointmentsCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <MedsCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
             <NotesCard petId={pet.id} canEdit={pet.role !== "Viewer"} />
+            <TimelineCard petId={pet.id} />
             <ImportWeightCard
                 petId={pet.id}
                 canEdit={pet.role !== "Viewer"}

--- a/src/app/dashboard/pets/[id]/report/_components/print-button.tsx
+++ b/src/app/dashboard/pets/[id]/report/_components/print-button.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Printer } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+
+export function PrintButton() {
+    return (
+        <Button
+            type="button"
+            size="sm"
+            onClick={() => window.print()}
+            className="print:hidden"
+        >
+            <Printer className="mr-1 h-3.5 w-3.5" />
+            Print / Save as PDF
+        </Button>
+    );
+}

--- a/src/app/dashboard/pets/[id]/report/page.tsx
+++ b/src/app/dashboard/pets/[id]/report/page.tsx
@@ -1,0 +1,362 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+import { TRPCError } from "@trpc/server";
+
+import { Button } from "~/components/ui/button";
+import { PetAvatar } from "~/components/ui/pet-avatar";
+import { PrintButton } from "~/app/dashboard/pets/[id]/report/_components/print-button";
+import { formatWeight } from "~/lib/units";
+import { api } from "~/trpc/server";
+
+const SECTION_TITLE =
+    "mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground";
+const TH =
+    "border-b py-1.5 pr-4 text-left text-xs font-medium uppercase text-muted-foreground";
+const TD = "border-b border-border/60 py-1.5 pr-4 align-top";
+const EMPTY = "text-sm text-muted-foreground";
+
+function ageLabel(birthDate: string | null): string | null {
+    if (!birthDate) return null;
+    const born = new Date(birthDate);
+    const now = new Date();
+    const months =
+        (now.getFullYear() - born.getFullYear()) * 12 +
+        (now.getMonth() - born.getMonth());
+    if (months < 12) return `${months} mo old`;
+    return `${Math.floor(months / 12)} yr old`;
+}
+
+function frequencyLabel(hours: number): string {
+    if (hours % 24 === 0) {
+        const days = hours / 24;
+        return days === 1 ? "Daily" : `Every ${days} days`;
+    }
+    return `Every ${hours}h`;
+}
+
+export async function generateMetadata({
+    params,
+}: {
+    params: { id: string };
+}) {
+    const petId = Number(params.id);
+    if (!Number.isFinite(petId) || petId <= 0) {
+        return { title: "Health report" };
+    }
+    try {
+        const pet = await api.pet.getPet({ petId });
+        return { title: `${pet.name} — Health report` };
+    } catch {
+        return { title: "Health report" };
+    }
+}
+
+export default async function PetReportPage({
+    params,
+}: {
+    params: { id: string };
+}) {
+    const petId = Number(params.id);
+    if (!Number.isFinite(petId) || petId <= 0) notFound();
+
+    let pet;
+    try {
+        pet = await api.pet.getPet({ petId });
+    } catch (err) {
+        if (
+            err instanceof TRPCError &&
+            (err.code === "FORBIDDEN" || err.code === "NOT_FOUND")
+        ) {
+            notFound();
+        }
+        throw err;
+    }
+
+    const [weights, healthEvents, appointments, meds, notes, prefs] =
+        await Promise.all([
+            api.weight.getWeightHistory({ petId }),
+            api.health.getHistory({ petId }),
+            api.appointments.list({ petId }),
+            api.meds.list({ petId }),
+            api.notes.getNotes({ petId }),
+            api.preferences.get(),
+        ]);
+
+    const unit = prefs.weightUnit;
+    const latest = weights[weights.length - 1] ?? null;
+    const recentWeights = [...weights].reverse();
+    const WEIGHT_ROW_CAP = 30;
+    const shownWeights = recentWeights.slice(0, WEIGHT_ROW_CAP);
+    const now = Date.now();
+    const activeMeds = meds.filter(
+        (m) => m.endsAt === null || m.endsAt.getTime() > now,
+    ).length;
+
+    return (
+        <div className="mx-auto max-w-3xl space-y-8">
+            <div className="flex items-center justify-between print:hidden">
+                <Button asChild variant="ghost" size="sm" className="-ml-2">
+                    <Link href={`/dashboard/pets/${pet.id}`}>
+                        <ChevronLeft className="mr-1 h-4 w-4" />
+                        Back to {pet.name}
+                    </Link>
+                </Button>
+                <PrintButton />
+            </div>
+
+            <header className="flex items-start gap-4 border-b pb-6">
+                <PetAvatar
+                    name={pet.name}
+                    photoUrl={pet.photoUrl}
+                    size="lg"
+                />
+                <div className="flex-1">
+                    <h1 className="text-2xl font-bold">
+                        {pet.name} — Health report
+                    </h1>
+                    <p className="text-sm text-muted-foreground">
+                        {[pet.species, pet.gender, ageLabel(pet.birthDate)]
+                            .filter(Boolean)
+                            .join(" · ")}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                        Generated {new Date().toLocaleString()}
+                    </p>
+                </div>
+            </header>
+
+            <section>
+                <h2 className={SECTION_TITLE}>Summary</h2>
+                <dl className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3">
+                    {[
+                        {
+                            label: "Current weight",
+                            value: latest
+                                ? formatWeight(latest.weight, unit)
+                                : "—",
+                        },
+                        {
+                            label: "Goal weight",
+                            value:
+                                pet.goalWeight !== null
+                                    ? formatWeight(pet.goalWeight, unit)
+                                    : "—",
+                        },
+                        {
+                            label: "Daily kcal target",
+                            value:
+                                pet.dailyKcalTarget !== null
+                                    ? `${pet.dailyKcalTarget} kcal`
+                                    : "—",
+                        },
+                        {
+                            label: "Weigh-ins",
+                            value: String(weights.length),
+                        },
+                        {
+                            label: "Health events",
+                            value: String(healthEvents.length),
+                        },
+                        {
+                            label: "Active medications",
+                            value: String(activeMeds),
+                        },
+                    ].map((stat) => (
+                        <div key={stat.label}>
+                            <dt className="text-xs text-muted-foreground">
+                                {stat.label}
+                            </dt>
+                            <dd className="font-medium">{stat.value}</dd>
+                        </div>
+                    ))}
+                </dl>
+            </section>
+
+            <section>
+                <h2 className={SECTION_TITLE}>
+                    Weight history
+                    {weights.length > WEIGHT_ROW_CAP &&
+                        ` — most recent ${WEIGHT_ROW_CAP} of ${weights.length}`}
+                </h2>
+                {shownWeights.length === 0 ? (
+                    <p className={EMPTY}>No weigh-ins recorded.</p>
+                ) : (
+                    <table className="w-full border-collapse text-sm">
+                        <thead>
+                            <tr>
+                                <th className={TH}>Date</th>
+                                <th className={TH}>Weight</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {shownWeights.map((w) => (
+                                <tr key={w.id}>
+                                    <td className={TD}>
+                                        {w.weighedAt.toLocaleDateString()}
+                                    </td>
+                                    <td className={TD}>
+                                        {formatWeight(w.weight, unit)}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </section>
+
+            <section>
+                <h2 className={SECTION_TITLE}>Health events</h2>
+                {healthEvents.length === 0 ? (
+                    <p className={EMPTY}>No health events recorded.</p>
+                ) : (
+                    <table className="w-full border-collapse text-sm">
+                        <thead>
+                            <tr>
+                                <th className={TH}>Date</th>
+                                <th className={TH}>Type</th>
+                                <th className={TH}>Event</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {healthEvents.map((e) => (
+                                <tr key={e.id}>
+                                    <td className={TD}>
+                                        {e.occurredAt.toLocaleDateString()}
+                                    </td>
+                                    <td className={TD}>{e.eventType}</td>
+                                    <td className={TD}>
+                                        <span className="font-medium">
+                                            {e.title}
+                                        </span>
+                                        {e.notes && (
+                                            <span className="block text-xs text-muted-foreground">
+                                                {e.notes}
+                                            </span>
+                                        )}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </section>
+
+            <section>
+                <h2 className={SECTION_TITLE}>Appointments</h2>
+                {appointments.length === 0 ? (
+                    <p className={EMPTY}>No appointments recorded.</p>
+                ) : (
+                    <table className="w-full border-collapse text-sm">
+                        <thead>
+                            <tr>
+                                <th className={TH}>Date</th>
+                                <th className={TH}>Type</th>
+                                <th className={TH}>Appointment</th>
+                                <th className={TH}>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {appointments.map((a) => (
+                                <tr key={a.id}>
+                                    <td className={TD}>
+                                        {a.scheduledFor.toLocaleString()}
+                                    </td>
+                                    <td className={TD}>
+                                        {a.appointmentType}
+                                    </td>
+                                    <td className={TD}>
+                                        <span className="font-medium">
+                                            {a.title}
+                                        </span>
+                                        {a.location && (
+                                            <span className="block text-xs text-muted-foreground">
+                                                {a.location}
+                                            </span>
+                                        )}
+                                        {a.notes && (
+                                            <span className="block text-xs text-muted-foreground">
+                                                {a.notes}
+                                            </span>
+                                        )}
+                                    </td>
+                                    <td className={TD}>{a.status}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </section>
+
+            <section>
+                <h2 className={SECTION_TITLE}>Medications</h2>
+                {meds.length === 0 ? (
+                    <p className={EMPTY}>No medications recorded.</p>
+                ) : (
+                    <table className="w-full border-collapse text-sm">
+                        <thead>
+                            <tr>
+                                <th className={TH}>Medication</th>
+                                <th className={TH}>Dosage</th>
+                                <th className={TH}>Frequency</th>
+                                <th className={TH}>Started</th>
+                                <th className={TH}>Ends</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {meds.map((m) => (
+                                <tr key={m.id}>
+                                    <td className={TD}>
+                                        <span className="font-medium">
+                                            {m.name}
+                                        </span>
+                                        {m.notes && (
+                                            <span className="block text-xs text-muted-foreground">
+                                                {m.notes}
+                                            </span>
+                                        )}
+                                    </td>
+                                    <td className={TD}>{m.dosage ?? "—"}</td>
+                                    <td className={TD}>
+                                        {frequencyLabel(m.frequencyHours)}
+                                    </td>
+                                    <td className={TD}>
+                                        {m.startsAt.toLocaleDateString()}
+                                    </td>
+                                    <td className={TD}>
+                                        {m.endsAt
+                                            ? m.endsAt.toLocaleDateString()
+                                            : "Ongoing"}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </section>
+
+            <section>
+                <h2 className={SECTION_TITLE}>Notes</h2>
+                {notes.length === 0 ? (
+                    <p className={EMPTY}>No notes recorded.</p>
+                ) : (
+                    <ul className="space-y-2 text-sm">
+                        {notes.map((n) => (
+                            <li
+                                key={n.id}
+                                className="border-b border-border/60 pb-2 last:border-0"
+                            >
+                                <div className="text-xs text-muted-foreground">
+                                    {n.writtenAt.toLocaleString()}
+                                </div>
+                                <p className="whitespace-pre-wrap break-words">
+                                    {n.body}
+                                </p>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </section>
+        </div>
+    );
+}

--- a/src/schema/addPetPhotoInput.ts
+++ b/src/schema/addPetPhotoInput.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const addPetPhotoInput = z.object({
+    petId: z.number().int().positive(),
+    url: z.string().url().max(1024),
+    caption: z.string().max(256).optional(),
+    takenAt: z.date().optional(),
+});

--- a/src/schema/createAppointmentInput.ts
+++ b/src/schema/createAppointmentInput.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const createAppointmentInput = z.object({
+    petId: z.number().int().positive(),
+    title: z.string().min(1).max(256),
+    appointmentType: z.string().min(1).max(64),
+    scheduledFor: z.date(),
+    location: z.string().max(256).optional(),
+    notes: z.string().max(2048).optional(),
+});

--- a/src/schema/updateAppointmentInput.ts
+++ b/src/schema/updateAppointmentInput.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const appointmentStatusSchema = z.enum([
+    "Scheduled",
+    "Completed",
+    "Cancelled",
+]);
+
+export const updateAppointmentInput = z.object({
+    appointmentId: z.number().int().positive(),
+    title: z.string().min(1).max(256).optional(),
+    appointmentType: z.string().min(1).max(64).optional(),
+    scheduledFor: z.date().optional(),
+    location: z.string().max(256).nullable().optional(),
+    notes: z.string().max(2048).nullable().optional(),
+});

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -8,6 +8,7 @@ import { activityRouter } from "~/server/api/routers/activity";
 import { healthRouter } from "~/server/api/routers/health";
 import { medsRouter } from "~/server/api/routers/meds";
 import { notesRouter } from "~/server/api/routers/notes";
+import { photosRouter } from "~/server/api/routers/photos";
 import { preferencesRouter } from "~/server/api/routers/preferences";
 
 /**
@@ -24,6 +25,7 @@ export const appRouter = createTRPCRouter({
   health: healthRouter,
   meds: medsRouter,
   notes: notesRouter,
+  photos: photosRouter,
   preferences: preferencesRouter,
   account: accountRouter,
 });

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -10,6 +10,7 @@ import { healthRouter } from "~/server/api/routers/health";
 import { medsRouter } from "~/server/api/routers/meds";
 import { notesRouter } from "~/server/api/routers/notes";
 import { photosRouter } from "~/server/api/routers/photos";
+import { timelineRouter } from "~/server/api/routers/timeline";
 import { preferencesRouter } from "~/server/api/routers/preferences";
 
 /**
@@ -28,6 +29,7 @@ export const appRouter = createTRPCRouter({
   notes: notesRouter,
   photos: photosRouter,
   appointments: appointmentsRouter,
+  timeline: timelineRouter,
   preferences: preferencesRouter,
   account: accountRouter,
 });

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,5 +1,6 @@
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 import { accountRouter } from "~/server/api/routers/account";
+import { appointmentsRouter } from "~/server/api/routers/appointments";
 import { petRouter } from "~/server/api/routers/pet";
 import { weightRouter } from "~/server/api/routers/weight";
 import { feedingRouter } from "~/server/api/routers/feeding";
@@ -26,6 +27,7 @@ export const appRouter = createTRPCRouter({
   meds: medsRouter,
   notes: notesRouter,
   photos: photosRouter,
+  appointments: appointmentsRouter,
   preferences: preferencesRouter,
   account: accountRouter,
 });

--- a/src/server/api/routers/appointments.ts
+++ b/src/server/api/routers/appointments.ts
@@ -1,0 +1,157 @@
+import { desc, eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { type db } from "~/server/db";
+import { petAppointments } from "~/server/db/schema";
+import { createAppointmentInput } from "~/schema/createAppointmentInput";
+import {
+    appointmentStatusSchema,
+    updateAppointmentInput,
+} from "~/schema/updateAppointmentInput";
+import { assertPetAccess } from "~/server/api/petAccess";
+
+async function loadAppointmentPetId(
+    database: typeof db,
+    appointmentId: number,
+): Promise<number> {
+    const [row] = await database
+        .select({ petId: petAppointments.petId })
+        .from(petAppointments)
+        .where(eq(petAppointments.id, appointmentId))
+        .limit(1);
+    if (!row) {
+        throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Appointment not found.",
+        });
+    }
+    return row.petId;
+}
+
+export const appointmentsRouter = createTRPCRouter({
+    list: protectedProcedure
+        .input(z.object({ petId: z.number().int().positive() }))
+        .query(async ({ ctx, input }) => {
+            await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            return ctx.db
+                .select()
+                .from(petAppointments)
+                .where(eq(petAppointments.petId, input.petId))
+                .orderBy(desc(petAppointments.scheduledFor));
+        }),
+
+    create: protectedProcedure
+        .input(createAppointmentInput)
+        .mutation(async ({ ctx, input }) => {
+            const role = await assertPetAccess(
+                ctx.db,
+                ctx.userId,
+                input.petId,
+            );
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot add appointments.",
+                });
+            }
+            const [row] = await ctx.db
+                .insert(petAppointments)
+                .values({
+                    petId: input.petId,
+                    title: input.title,
+                    appointmentType: input.appointmentType,
+                    scheduledFor: input.scheduledFor,
+                    location: input.location ?? null,
+                    notes: input.notes ?? null,
+                    createdBy: ctx.userId,
+                })
+                .returning();
+            if (!row) throw new Error("Failed to create appointment.");
+            return row;
+        }),
+
+    updateEntry: protectedProcedure
+        .input(updateAppointmentInput)
+        .mutation(async ({ ctx, input }) => {
+            const petId = await loadAppointmentPetId(
+                ctx.db,
+                input.appointmentId,
+            );
+            const role = await assertPetAccess(ctx.db, ctx.userId, petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot edit appointments.",
+                });
+            }
+            const patch: Record<string, unknown> = { updatedAt: new Date() };
+            if (input.title !== undefined) patch.title = input.title;
+            if (input.appointmentType !== undefined)
+                patch.appointmentType = input.appointmentType;
+            if (input.scheduledFor !== undefined)
+                patch.scheduledFor = input.scheduledFor;
+            if (input.location !== undefined) patch.location = input.location;
+            if (input.notes !== undefined) patch.notes = input.notes;
+
+            const [row] = await ctx.db
+                .update(petAppointments)
+                .set(patch)
+                .where(eq(petAppointments.id, input.appointmentId))
+                .returning();
+            if (!row) {
+                throw new TRPCError({
+                    code: "INTERNAL_SERVER_ERROR",
+                    message: "Failed to update appointment.",
+                });
+            }
+            return row;
+        }),
+
+    setStatus: protectedProcedure
+        .input(
+            z.object({
+                appointmentId: z.number().int().positive(),
+                status: appointmentStatusSchema,
+            }),
+        )
+        .mutation(async ({ ctx, input }) => {
+            const petId = await loadAppointmentPetId(
+                ctx.db,
+                input.appointmentId,
+            );
+            const role = await assertPetAccess(ctx.db, ctx.userId, petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot change appointments.",
+                });
+            }
+            await ctx.db
+                .update(petAppointments)
+                .set({ status: input.status, updatedAt: new Date() })
+                .where(eq(petAppointments.id, input.appointmentId));
+            return { ok: true as const };
+        }),
+
+    deleteEntry: protectedProcedure
+        .input(z.object({ appointmentId: z.number().int().positive() }))
+        .mutation(async ({ ctx, input }) => {
+            const petId = await loadAppointmentPetId(
+                ctx.db,
+                input.appointmentId,
+            );
+            const role = await assertPetAccess(ctx.db, ctx.userId, petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot delete appointments.",
+                });
+            }
+            await ctx.db
+                .delete(petAppointments)
+                .where(eq(petAppointments.id, input.appointmentId));
+            return { ok: true as const };
+        }),
+});

--- a/src/server/api/routers/photos.ts
+++ b/src/server/api/routers/photos.ts
@@ -1,0 +1,107 @@
+import { and, desc, eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { type db } from "~/server/db";
+import { petPhotos, pets } from "~/server/db/schema";
+import { addPetPhotoInput } from "~/schema/addPetPhotoInput";
+import { assertPetAccess } from "~/server/api/petAccess";
+
+async function loadPhoto(database: typeof db, photoId: number) {
+    const [row] = await database
+        .select()
+        .from(petPhotos)
+        .where(eq(petPhotos.id, photoId))
+        .limit(1);
+    if (!row) {
+        throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Photo not found.",
+        });
+    }
+    return row;
+}
+
+export const photosRouter = createTRPCRouter({
+    list: protectedProcedure
+        .input(z.object({ petId: z.number().int().positive() }))
+        .query(async ({ ctx, input }) => {
+            await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            return ctx.db
+                .select()
+                .from(petPhotos)
+                .where(eq(petPhotos.petId, input.petId))
+                .orderBy(desc(petPhotos.takenAt));
+        }),
+
+    add: protectedProcedure
+        .input(addPetPhotoInput)
+        .mutation(async ({ ctx, input }) => {
+            const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot add photos.",
+                });
+            }
+            const [row] = await ctx.db
+                .insert(petPhotos)
+                .values({
+                    petId: input.petId,
+                    url: input.url,
+                    caption: input.caption ?? null,
+                    takenAt: input.takenAt ?? new Date(),
+                    uploadedBy: ctx.userId,
+                })
+                .returning();
+            if (!row) throw new Error("Failed to add photo.");
+            return row;
+        }),
+
+    remove: protectedProcedure
+        .input(z.object({ photoId: z.number().int().positive() }))
+        .mutation(async ({ ctx, input }) => {
+            const photo = await loadPhoto(ctx.db, input.photoId);
+            const role = await assertPetAccess(ctx.db, ctx.userId, photo.petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot delete photos.",
+                });
+            }
+            await ctx.db
+                .delete(petPhotos)
+                .where(eq(petPhotos.id, input.photoId));
+            // If this photo was also the pet's avatar, clear it so the UI
+            // doesn't keep pointing at a now-deleted gallery entry.
+            await ctx.db
+                .update(pets)
+                .set({ photoUrl: null, updatedAt: new Date() })
+                .where(
+                    and(
+                        eq(pets.id, photo.petId),
+                        eq(pets.photoUrl, photo.url),
+                    ),
+                );
+            return { ok: true as const };
+        }),
+
+    setPrimary: protectedProcedure
+        .input(z.object({ photoId: z.number().int().positive() }))
+        .mutation(async ({ ctx, input }) => {
+            const photo = await loadPhoto(ctx.db, input.photoId);
+            const role = await assertPetAccess(ctx.db, ctx.userId, photo.petId);
+            if (role === "Viewer") {
+                throw new TRPCError({
+                    code: "FORBIDDEN",
+                    message: "Viewer role cannot change the primary photo.",
+                });
+            }
+            await ctx.db
+                .update(pets)
+                .set({ photoUrl: photo.url, updatedAt: new Date() })
+                .where(eq(pets.id, photo.petId));
+            return { ok: true as const };
+        }),
+});

--- a/src/server/api/routers/timeline.ts
+++ b/src/server/api/routers/timeline.ts
@@ -1,0 +1,102 @@
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import {
+    activityHistory,
+    eatingHistory,
+    healthEvents,
+    petFood,
+    petNotes,
+    weightHistory,
+} from "~/server/db/schema";
+import { assertPetAccess } from "~/server/api/petAccess";
+
+// A merged, newest-first view of everything that has happened to a pet:
+// weigh-ins, feedings, activity, health events, and notes. Each kind keeps
+// its own raw fields so the client can format them (e.g. weight in the
+// viewer's preferred unit) and link back to the source card.
+export const timelineRouter = createTRPCRouter({
+    get: protectedProcedure
+        .input(z.object({ petId: z.number().int().positive() }))
+        .query(async ({ ctx, input }) => {
+            await assertPetAccess(ctx.db, ctx.userId, input.petId);
+            const petId = input.petId;
+
+            const [weights, feedings, activities, healthRows, notes] =
+                await Promise.all([
+                    ctx.db
+                        .select()
+                        .from(weightHistory)
+                        .where(eq(weightHistory.petId, petId)),
+                    ctx.db
+                        .select({
+                            id: eatingHistory.id,
+                            fedAt: eatingHistory.fedAt,
+                            quantityGrams: eatingHistory.quantityGrams,
+                            foodName: petFood.name,
+                        })
+                        .from(eatingHistory)
+                        .innerJoin(
+                            petFood,
+                            eq(petFood.id, eatingHistory.foodId),
+                        )
+                        .where(eq(eatingHistory.petId, petId)),
+                    ctx.db
+                        .select()
+                        .from(activityHistory)
+                        .where(eq(activityHistory.petId, petId)),
+                    ctx.db
+                        .select()
+                        .from(healthEvents)
+                        .where(eq(healthEvents.petId, petId)),
+                    ctx.db
+                        .select()
+                        .from(petNotes)
+                        .where(eq(petNotes.petId, petId)),
+                ]);
+
+            const items = [
+                ...weights.map((w) => ({
+                    kind: "weight" as const,
+                    id: w.id,
+                    occurredAt: w.weighedAt,
+                    weightKg: w.weight,
+                })),
+                ...feedings.map((f) => ({
+                    kind: "feeding" as const,
+                    id: f.id,
+                    occurredAt: f.fedAt,
+                    foodName: f.foodName,
+                    quantityGrams: f.quantityGrams,
+                })),
+                ...activities.map((a) => ({
+                    kind: "activity" as const,
+                    id: a.id,
+                    occurredAt: a.performedAt,
+                    activityType: a.activityType,
+                    durationMinutes: a.durationMinutes,
+                    notes: a.notes,
+                })),
+                ...healthRows.map((h) => ({
+                    kind: "health" as const,
+                    id: h.id,
+                    occurredAt: h.occurredAt,
+                    eventType: h.eventType,
+                    title: h.title,
+                    notes: h.notes,
+                })),
+                ...notes.map((n) => ({
+                    kind: "note" as const,
+                    id: n.id,
+                    occurredAt: n.writtenAt,
+                    body: n.body,
+                })),
+            ];
+
+            items.sort(
+                (a, b) => b.occurredAt.getTime() - a.occurredAt.getTime(),
+            );
+            return items;
+        }),
+});

--- a/src/server/api/routers/weight.ts
+++ b/src/server/api/routers/weight.ts
@@ -1,10 +1,10 @@
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { type db } from "~/server/db";
-import { weightHistory } from "~/server/db/schema";
+import { petPeople, pets, weightHistory } from "~/server/db/schema";
 import { getWeightHistoryInput } from "~/schema/getPetWeightInput";
 import { recordWeightInput } from "~/schema/recordPetWeightInput";
 import {
@@ -65,6 +65,59 @@ export const weightRouter = createTRPCRouter({
                 .where(eq(weightHistory.petId, input.petId))
                 .orderBy(asc(weightHistory.weighedAt));
         }),
+
+    // Weight series for every non-deleted pet the user can access, for the
+    // multi-pet comparison view. The petPeople join scopes to the user, so
+    // no per-pet assertPetAccess is needed.
+    getComparison: protectedProcedure.query(async ({ ctx }) => {
+        const userPets = await ctx.db
+            .select({
+                id: pets.id,
+                name: pets.name,
+                goalWeight: pets.goalWeight,
+            })
+            .from(pets)
+            .innerJoin(petPeople, eq(pets.id, petPeople.petId))
+            .where(
+                and(
+                    eq(petPeople.userId, ctx.userId),
+                    isNull(pets.deletedAt),
+                ),
+            );
+        if (userPets.length === 0) return [];
+
+        const rows = await ctx.db
+            .select({
+                petId: weightHistory.petId,
+                weighedAt: weightHistory.weighedAt,
+                weight: weightHistory.weight,
+            })
+            .from(weightHistory)
+            .where(
+                inArray(
+                    weightHistory.petId,
+                    userPets.map((p) => p.id),
+                ),
+            )
+            .orderBy(asc(weightHistory.weighedAt));
+
+        const pointsByPet = new Map<
+            number,
+            { weighedAt: Date; weight: number }[]
+        >();
+        for (const row of rows) {
+            const list = pointsByPet.get(row.petId) ?? [];
+            list.push({ weighedAt: row.weighedAt, weight: row.weight });
+            pointsByPet.set(row.petId, list);
+        }
+
+        return userPets.map((p) => ({
+            petId: p.id,
+            petName: p.name,
+            goalWeight: p.goalWeight,
+            points: pointsByPet.get(p.id) ?? [],
+        }));
+    }),
 
     updateEntry: protectedProcedure
         .input(updateWeightEntryInput)

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -235,3 +235,26 @@ export const healthEvents = createTable(
         petIdx: index("health_events_pet_id_idx").on(table.petId),
     }),
 );
+
+// Gallery of photos for a pet, captured over time. The pet's "primary"
+// photo is still `pets.photoUrl`; a gallery row is promoted to primary by
+// copying its `url` there (see the photos router `setPrimary`).
+export const petPhotos = createTable(
+    "pet_photos",
+    {
+        id: serial("id").primaryKey(),
+        petId: integer("pet_id")
+            .references(() => pets.id)
+            .notNull(),
+        url: varchar("url", { length: 1024 }).notNull(),
+        caption: varchar("caption", { length: 256 }),
+        takenAt: timestamp("taken_at", { withTimezone: true }).notNull(),
+        uploadedBy: varchar("uploaded_by", { length: 256 })
+            .references(() => users.id)
+            .notNull(),
+        ...timestamps,
+    },
+    (table) => ({
+        petIdx: index("pet_photos_pet_id_idx").on(table.petId),
+    }),
+);

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -258,3 +258,37 @@ export const petPhotos = createTable(
         petIdx: index("pet_photos_pet_id_idx").on(table.petId),
     }),
 );
+
+export const appointmentStatusEnum = pgEnum("appointment_status", [
+    "Scheduled",
+    "Completed",
+    "Cancelled",
+]);
+
+// Upcoming (and past) vet/grooming appointments. Distinct from
+// health_events, which is a log of things that already happened — an
+// appointment has a forward-looking schedule and a lifecycle status.
+export const petAppointments = createTable(
+    "pet_appointments",
+    {
+        id: serial("id").primaryKey(),
+        petId: integer("pet_id")
+            .references(() => pets.id)
+            .notNull(),
+        title: varchar("title", { length: 256 }).notNull(),
+        appointmentType: varchar("appointment_type", { length: 64 }).notNull(),
+        scheduledFor: timestamp("scheduled_for", {
+            withTimezone: true,
+        }).notNull(),
+        location: varchar("location", { length: 256 }),
+        notes: varchar("notes", { length: 2048 }),
+        status: appointmentStatusEnum("status").notNull().default("Scheduled"),
+        createdBy: varchar("created_by", { length: 256 })
+            .references(() => users.id)
+            .notNull(),
+        ...timestamps,
+    },
+    (table) => ({
+        petIdx: index("pet_appointments_pet_id_idx").on(table.petId),
+    }),
+);


### PR DESCRIPTION
## Summary

Batch 7 — feature-depth work, stacked on the Batch 6 tip (`claude/a11y-pass` @ S62). Nine stories, one commit each:

- **S63 — `pet_photos` table + photos router.** Multi-photo gallery alongside the existing single `pets.photoUrl` avatar; `list`/`add`/`remove`/`setPrimary` with the usual pet-access + role checks. `setPrimary` promotes a gallery photo by copying its url into `pets.photoUrl`.
- **S64 — photo gallery card.** Thumbnail grid on the pet detail page with captions/dates; editors upload via the existing Blob route then `photos.add`, set a primary, or delete.
- **S65 — `pet_appointments` table + appointments router.** Separate table (per chosen approach) with a `Scheduled`/`Completed`/`Cancelled` lifecycle, kept distinct from `health_events`. Router: `list`/`create`/`updateEntry`/`setStatus`/`deleteEntry`.
- **S66 — appointments card.** Upcoming / Past & closed split, overdue flagging, a shared add/edit dialog, and inline complete/cancel/reopen.
- **S67 — appointment reminders in the daily cron.** After the feeding pass, emails Owners/Editors about `Scheduled` appointments in the next 24h; reuses the recipient lookup + daily-reminder opt-out and renders times in each recipient's saved timezone (email fields HTML-escaped).
- **S68 — unified per-pet history timeline.** `timeline` router merges weigh-ins, feedings, activity, health events, and notes into one newest-first list; Timeline card renders each with a kind icon. Weights format in the viewer's unit.
- **S69 — timeline search & filter.** Client-side text search, per-kind toggles, and a from/to date range with a result count + clear control.
- **S70 — multi-pet weight comparison.** `weight.getComparison` returns every accessible pet's weight series; `/dashboard/compare` overlays them on one chart with per-pet show/hide toggles and a 30d/90d/all range picker. Linked from the dashboard when >1 pet.
- **S71 — printable health report.** `/dashboard/pets/[id]/report` — a print-optimized one-pager (vitals, weight history, health events, appointments, meds, notes) with a Print / Save as PDF button. Nav bars are now `print:hidden`.

Adds Drizzle migrations `0011` (`pet_photos`) and `0012` (`pet_appointments` + `appointment_status` enum).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean on all touched files
- [x] `pnpm build` — succeeds; new `/dashboard/compare` and `/dashboard/pets/[id]/report` routes compile
- [x] `pnpm test` — 76/76 passing
- [ ] Manual browser QA — **not done in this environment** (no DB / Clerk / Blob credentials available). Needs a human pass: photo upload + set-primary/delete, appointment create/edit/status, timeline filters, comparison chart toggles, and the report page's print layout.
- [ ] Run `pnpm db:migrate` (or `db:push`) to apply migrations `0011` / `0012` before deploy.

https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_