### PR TITLE
Batch 8: quality &amp; hardening — CI fix, tests, skeletons

### DIFF
--- a/src/app/api/cron/daily-reminders/route.test.ts
+++ b/src/app/api/cron/daily-reminders/route.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mutable env the route reads inside GET; reset before each test.
+const { mockEnv } = vi.hoisted(() => ({
+    mockEnv: {} as Record<string, string | undefined>,
+}));
+vi.mock("~/env", () => ({ env: mockEnv }));
+
+// The route imports db/Resend/clerkClient at module load. The guard-path
+// tests never reach them; the "no pets" test only needs every query to
+// resolve to an empty array.
+vi.mock("~/server/db", () => {
+    const chain: Record<string, unknown> = {};
+    Object.assign(chain, {
+        from: () => chain,
+        where: () => chain,
+        innerJoin: () => chain,
+        orderBy: () => chain,
+        limit: () => Promise.resolve([]),
+        then: (onFulfilled: (rows: unknown[]) => unknown) =>
+            Promise.resolve([]).then(onFulfilled),
+    });
+    return { db: { select: () => chain } };
+});
+vi.mock("resend", () => ({
+    Resend: class {
+        emails = { send: vi.fn() };
+    },
+}));
+vi.mock("@clerk/nextjs/server", () => ({
+    clerkClient: { users: { getUserList: vi.fn(async () => []) } },
+}));
+
+import { GET } from "./route";
+
+const URL = "http://localhost/api/cron/daily-reminders";
+
+beforeEach(() => {
+    for (const key of Object.keys(mockEnv)) delete mockEnv[key];
+});
+
+describe("daily-reminders cron", () => {
+    it("returns 401 when CRON_SECRET is set and the auth header is missing", async () => {
+        mockEnv.CRON_SECRET = "s3cret";
+        const res = await GET(new Request(URL));
+        expect(res.status).toBe(401);
+    });
+
+    it("returns 401 when CRON_SECRET is set and the auth header is wrong", async () => {
+        mockEnv.CRON_SECRET = "s3cret";
+        const res = await GET(
+            new Request(URL, {
+                headers: { authorization: "Bearer wrong" },
+            }),
+        );
+        expect(res.status).toBe(401);
+    });
+
+    it("no-ops with 200 when RESEND is not configured", async () => {
+        // CRON_SECRET unset -> auth skipped; RESEND_API_KEY unset -> no-op.
+        const res = await GET(new Request(URL));
+        expect(res.status).toBe(200);
+        expect(await res.text()).toMatch(/not configured/i);
+    });
+
+    it("no-ops when RESEND_FROM is missing even with an API key", async () => {
+        mockEnv.RESEND_API_KEY = "re_test";
+        const res = await GET(new Request(URL));
+        expect(res.status).toBe(200);
+        expect(await res.text()).toMatch(/not configured/i);
+    });
+
+    it("runs and returns empty summaries when configured with no pets", async () => {
+        mockEnv.CRON_SECRET = "s3cret";
+        mockEnv.RESEND_API_KEY = "re_test";
+        mockEnv.RESEND_FROM = "noreply@example.com";
+        const res = await GET(
+            new Request(URL, {
+                headers: { authorization: "Bearer s3cret" },
+            }),
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+            summary: unknown[];
+            appointmentSummary: unknown[];
+        };
+        expect(body.summary).toEqual([]);
+        expect(body.appointmentSummary).toEqual([]);
+    });
+});

--- a/src/app/api/cron/daily-reminders/route.ts
+++ b/src/app/api/cron/daily-reminders/route.ts
@@ -157,7 +157,9 @@ export async function GET(req: Request) {
             continue;
         }
         const subject = `${pet.name} hasn't been fed in ${hours}h`;
-        const html = `<p>Heads up: <strong>${pet.name}</strong> hasn't been fed in ${hours} hours.</p><p>Log a feeding from the Meow Weight Tracker dashboard.</p>`;
+        const html = `<p>Heads up: <strong>${escapeHtml(
+            pet.name,
+        )}</strong> hasn't been fed in ${hours} hours.</p><p>Log a feeding from the Meow Weight Tracker dashboard.</p>`;
         let sent = 0;
         for (const r of recipients) {
             try {

--- a/src/app/dashboard/foods/_components/food-list.tsx
+++ b/src/app/dashboard/foods/_components/food-list.tsx
@@ -4,13 +4,14 @@ import { Utensils } from "lucide-react";
 
 import { Card, CardContent } from "~/components/ui/card";
 import { EmptyState } from "~/components/ui/empty-state";
+import { ListSkeleton } from "~/components/ui/list-skeleton";
 import { api } from "~/trpc/react";
 
 export function FoodList() {
     const { data, isLoading } = api.food.list.useQuery();
 
     if (isLoading) {
-        return <p className="text-sm text-muted-foreground">Loading…</p>;
+        return <ListSkeleton />;
     }
     if (!data || data.length === 0) {
         return (

--- a/src/app/dashboard/pets/[id]/_components/appointments-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/appointments-card.tsx
@@ -30,6 +30,7 @@ import {
     DialogTrigger,
 } from "~/components/ui/dialog";
 import { EmptyState } from "~/components/ui/empty-state";
+import { ListSkeleton } from "~/components/ui/list-skeleton";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { api, type RouterOutputs } from "~/trpc/react";
@@ -89,7 +90,7 @@ export function AppointmentsCard({
             </CardHeader>
             <CardContent>
                 {isLoading ? (
-                    <p className="text-sm text-muted-foreground">Loading…</p>
+                    <ListSkeleton />
                 ) : all.length === 0 ? (
                     <EmptyState
                         icon={CalendarClock}

--- a/src/app/dashboard/pets/[id]/_components/feeding-history-list.tsx
+++ b/src/app/dashboard/pets/[id]/_components/feeding-history-list.tsx
@@ -12,6 +12,7 @@ import {
 } from "~/components/ui/card";
 import { FeedingRowActions } from "~/app/dashboard/_components/feeding-row-actions";
 import { EmptyState } from "~/components/ui/empty-state";
+import { ListSkeleton } from "~/components/ui/list-skeleton";
 import { api } from "~/trpc/react";
 import { type RouterOutputs } from "~/trpc/react";
 
@@ -40,7 +41,7 @@ export function FeedingHistoryList({
             </CardHeader>
             <CardContent>
                 {isLoading ? (
-                    <p className="text-sm text-muted-foreground">Loading…</p>
+                    <ListSkeleton />
                 ) : grouped.length === 0 ? (
                     <EmptyState
                         icon={Utensils}

--- a/src/app/dashboard/pets/[id]/_components/health-events-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/health-events-card.tsx
@@ -21,6 +21,7 @@ import {
     DialogTrigger,
 } from "~/components/ui/dialog";
 import { EmptyState } from "~/components/ui/empty-state";
+import { ListSkeleton } from "~/components/ui/list-skeleton";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { api } from "~/trpc/react";
@@ -173,7 +174,7 @@ export function HealthEventsCard({
             </CardHeader>
             <CardContent>
                 {isLoading ? (
-                    <p className="text-sm text-muted-foreground">Loading…</p>
+                    <ListSkeleton />
                 ) : !data || data.length === 0 ? (
                     <EmptyState
                         icon={HeartPulse}

--- a/src/app/dashboard/pets/[id]/_components/meds-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/meds-card.tsx
@@ -21,6 +21,7 @@ import {
     DialogTrigger,
 } from "~/components/ui/dialog";
 import { EmptyState } from "~/components/ui/empty-state";
+import { ListSkeleton } from "~/components/ui/list-skeleton";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { isMedDue, nextDueAt } from "~/lib/meds-due";
@@ -238,7 +239,7 @@ export function MedsCard({
             </CardHeader>
             <CardContent>
                 {isLoading ? (
-                    <p className="text-sm text-muted-foreground">Loading…</p>
+                    <ListSkeleton />
                 ) : !data || data.length === 0 ? (
                     <EmptyState
                         icon={Pill}

--- a/src/app/dashboard/pets/[id]/_components/notes-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/notes-card.tsx
@@ -13,6 +13,7 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { EmptyState } from "~/components/ui/empty-state";
+import { ListSkeleton } from "~/components/ui/list-skeleton";
 import { api } from "~/trpc/react";
 
 export function NotesCard({
@@ -83,7 +84,7 @@ export function NotesCard({
                     </form>
                 )}
                 {isLoading ? (
-                    <p className="text-sm text-muted-foreground">Loading…</p>
+                    <ListSkeleton />
                 ) : !data || data.length === 0 ? (
                     <EmptyState
                         icon={NotebookPen}

--- a/src/app/dashboard/pets/[id]/_components/photo-gallery-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/photo-gallery-card.tsx
@@ -22,6 +22,7 @@ import {
     DialogTrigger,
 } from "~/components/ui/dialog";
 import { EmptyState } from "~/components/ui/empty-state";
+import { Skeleton } from "~/components/ui/skeleton";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { api } from "~/trpc/react";
@@ -198,7 +199,18 @@ export function PhotoGalleryCard({
             </CardHeader>
             <CardContent>
                 {isLoading ? (
-                    <p className="text-sm text-muted-foreground">Loading…</p>
+                    <div role="status">
+                        <span className="sr-only">Loading…</span>
+                        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                            {Array.from({ length: 6 }).map((_, i) => (
+                                <Skeleton
+                                    key={i}
+                                    className="aspect-square w-full"
+                                    aria-hidden="true"
+                                />
+                            ))}
+                        </div>
+                    </div>
                 ) : !data || data.length === 0 ? (
                     <EmptyState
                         icon={Images}

--- a/src/app/dashboard/pets/[id]/_components/timeline-card.tsx
+++ b/src/app/dashboard/pets/[id]/_components/timeline-card.tsx
@@ -20,6 +20,7 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { EmptyState } from "~/components/ui/empty-state";
+import { ListSkeleton } from "~/components/ui/list-skeleton";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { useWeightUnit } from "~/hooks/use-weight-unit";
@@ -153,7 +154,7 @@ export function TimelineCard({ petId }: { petId: number }) {
             </CardHeader>
             <CardContent>
                 {isLoading ? (
-                    <p className="text-sm text-muted-foreground">Loading…</p>
+                    <ListSkeleton />
                 ) : !data || data.length === 0 ? (
                     <EmptyState
                         icon={History}

--- a/src/app/dashboard/pets/[id]/_components/weight-history-list.tsx
+++ b/src/app/dashboard/pets/[id]/_components/weight-history-list.tsx
@@ -14,6 +14,7 @@ import {
 } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
 import { EmptyState } from "~/components/ui/empty-state";
+import { ListSkeleton } from "~/components/ui/list-skeleton";
 import { useWeightUnit } from "~/hooks/use-weight-unit";
 import { formatWeight, toKg } from "~/lib/units";
 import { api } from "~/trpc/react";
@@ -41,7 +42,7 @@ export function WeightHistoryList({
             </CardHeader>
             <CardContent>
                 {isLoading ? (
-                    <p className="text-sm text-muted-foreground">Loading…</p>
+                    <ListSkeleton />
                 ) : sorted.length === 0 ? (
                     <EmptyState
                         icon={Scale}

--- a/src/app/dashboard/pets/[id]/people/_components/people-manager.tsx
+++ b/src/app/dashboard/pets/[id]/people/_components/people-manager.tsx
@@ -13,6 +13,7 @@ import {
     CardTitle,
 } from "~/components/ui/card";
 import { EmptyState } from "~/components/ui/empty-state";
+import { ListSkeleton } from "~/components/ui/list-skeleton";
 import { Label } from "~/components/ui/label";
 import { api } from "~/trpc/react";
 
@@ -84,7 +85,7 @@ export function PeopleManager({
                 </CardHeader>
                 <CardContent>
                     {people.isLoading ? (
-                        <p className="text-sm text-muted-foreground">Loading…</p>
+                        <ListSkeleton />
                     ) : !people.data || people.data.length === 0 ? (
                         <EmptyState
                             icon={Users}

--- a/src/components/ui/list-skeleton.tsx
+++ b/src/components/ui/list-skeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "~/components/ui/skeleton";
+
+/**
+ * Loading placeholder for list and table cards: a few full-width
+ * skeleton rows. role="status" + an sr-only label keeps the loading
+ * state announced to screen readers, which a bare skeleton would not.
+ */
+export function ListSkeleton({ rows = 3 }: { rows?: number }) {
+    return (
+        <div role="status" className="space-y-2">
+            <span className="sr-only">Loading…</span>
+            {Array.from({ length: rows }).map((_, i) => (
+                <Skeleton
+                    key={i}
+                    className="h-10 w-full"
+                    aria-hidden="true"
+                />
+            ))}
+        </div>
+    );
+}

--- a/src/server/api/routers/__tests__/appointments-router.test.ts
+++ b/src/server/api/routers/__tests__/appointments-router.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import { createCaller } from "~/server/api/root";
+import { makeStubDb, type StubScenario } from "./mock-db";
+
+function callerWith(scenario: StubScenario, userId = "u_1") {
+    const db = makeStubDb(scenario);
+    return createCaller({ db, userId, headers: new Headers() });
+}
+
+const SCHEDULED_FOR = new Date("2026-06-01T10:00:00Z");
+
+describe("appointments router", () => {
+    it("list returns appointments for an accessible pet", async () => {
+        const caller = callerWith({
+            selectRows: [
+                // assertPetAccess
+                [{ role: "Viewer" }],
+                // appointments.list query
+                [
+                    { id: 1, petId: 7, title: "Checkup", status: "Scheduled" },
+                    { id: 2, petId: 7, title: "Grooming", status: "Completed" },
+                ],
+            ],
+        });
+        const rows = await caller.appointments.list({ petId: 7 });
+        expect(rows).toHaveLength(2);
+    });
+
+    it("list rejects when the user has no access", async () => {
+        const caller = callerWith({ selectRows: [[]] });
+        await expect(
+            caller.appointments.list({ petId: 7 }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("create rejects Viewer role", async () => {
+        const caller = callerWith({ selectRows: [[{ role: "Viewer" }]] });
+        await expect(
+            caller.appointments.create({
+                petId: 7,
+                title: "Annual checkup",
+                appointmentType: "Vet visit",
+                scheduledFor: SCHEDULED_FOR,
+            }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("create succeeds for Editor", async () => {
+        const caller = callerWith({
+            selectRows: [[{ role: "Editor" }]],
+            insertRows: [{ id: 42, petId: 7, title: "Annual checkup" }],
+        });
+        const row = await caller.appointments.create({
+            petId: 7,
+            title: "Annual checkup",
+            appointmentType: "Vet visit",
+            scheduledFor: SCHEDULED_FOR,
+        });
+        expect((row as { id: number }).id).toBe(42);
+    });
+
+    it("create rejects a non-Date scheduledFor", async () => {
+        const caller = callerWith({});
+        await expect(
+            caller.appointments.create({
+                petId: 7,
+                title: "Annual checkup",
+                appointmentType: "Vet visit",
+                // @ts-expect-error - scheduledFor must be a Date
+                scheduledFor: "2026-06-01",
+            }),
+        ).rejects.toBeDefined();
+    });
+
+    it("updateEntry returns NOT_FOUND when the appointment is missing", async () => {
+        const caller = callerWith({ selectRows: [[]] });
+        await expect(
+            caller.appointments.updateEntry({
+                appointmentId: 9999,
+                title: "Rescheduled",
+            }),
+        ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    });
+
+    it("updateEntry rejects Viewer role", async () => {
+        const caller = callerWith({
+            selectRows: [
+                // loadAppointmentPetId
+                [{ petId: 7 }],
+                // assertPetAccess
+                [{ role: "Viewer" }],
+            ],
+        });
+        await expect(
+            caller.appointments.updateEntry({
+                appointmentId: 5,
+                title: "Rescheduled",
+            }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("updateEntry succeeds for Editor", async () => {
+        const caller = callerWith({
+            selectRows: [[{ petId: 7 }], [{ role: "Editor" }]],
+            updateRows: [{ id: 5, title: "Rescheduled" }],
+        });
+        const row = await caller.appointments.updateEntry({
+            appointmentId: 5,
+            title: "Rescheduled",
+        });
+        expect((row as { id: number }).id).toBe(5);
+    });
+
+    it("setStatus rejects Viewer role", async () => {
+        const caller = callerWith({
+            selectRows: [[{ petId: 7 }], [{ role: "Viewer" }]],
+        });
+        await expect(
+            caller.appointments.setStatus({
+                appointmentId: 5,
+                status: "Completed",
+            }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("setStatus succeeds for Editor", async () => {
+        const caller = callerWith({
+            selectRows: [[{ petId: 7 }], [{ role: "Editor" }]],
+        });
+        const result = await caller.appointments.setStatus({
+            appointmentId: 5,
+            status: "Completed",
+        });
+        expect(result).toEqual({ ok: true });
+    });
+
+    it("setStatus rejects an invalid status", async () => {
+        const caller = callerWith({});
+        await expect(
+            caller.appointments.setStatus({
+                appointmentId: 5,
+                // @ts-expect-error - status must be a known enum value
+                status: "Maybe",
+            }),
+        ).rejects.toBeDefined();
+    });
+
+    it("deleteEntry rejects Viewer role", async () => {
+        const caller = callerWith({
+            selectRows: [[{ petId: 7 }], [{ role: "Viewer" }]],
+        });
+        await expect(
+            caller.appointments.deleteEntry({ appointmentId: 5 }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("deleteEntry succeeds for Editor", async () => {
+        const caller = callerWith({
+            selectRows: [[{ petId: 7 }], [{ role: "Editor" }]],
+        });
+        const result = await caller.appointments.deleteEntry({
+            appointmentId: 5,
+        });
+        expect(result).toEqual({ ok: true });
+    });
+});

--- a/src/server/api/routers/__tests__/photos-router.test.ts
+++ b/src/server/api/routers/__tests__/photos-router.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { createCaller } from "~/server/api/root";
+import { makeStubDb, type StubScenario } from "./mock-db";
+
+function callerWith(scenario: StubScenario, userId = "u_1") {
+    const db = makeStubDb(scenario);
+    return createCaller({ db, userId, headers: new Headers() });
+}
+
+const PHOTO_URL = "https://blob.example.com/pet-photos/7/123.jpg";
+
+describe("photos router", () => {
+    it("list returns photos for a pet the user can access", async () => {
+        const caller = callerWith({
+            selectRows: [
+                // assertPetAccess
+                [{ role: "Viewer" }],
+                // photos.list query
+                [
+                    { id: 1, petId: 7, url: PHOTO_URL, caption: "Nap" },
+                    { id: 2, petId: 7, url: PHOTO_URL, caption: null },
+                ],
+            ],
+        });
+        const rows = await caller.photos.list({ petId: 7 });
+        expect(rows).toHaveLength(2);
+    });
+
+    it("list rejects when the user has no access", async () => {
+        const caller = callerWith({ selectRows: [[]] });
+        await expect(
+            caller.photos.list({ petId: 7 }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("add rejects a non-URL value", async () => {
+        const caller = callerWith({});
+        await expect(
+            caller.photos.add({ petId: 7, url: "not-a-url" }),
+        ).rejects.toBeDefined();
+    });
+
+    it("add rejects Viewer role", async () => {
+        const caller = callerWith({ selectRows: [[{ role: "Viewer" }]] });
+        await expect(
+            caller.photos.add({ petId: 7, url: PHOTO_URL }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("add succeeds for Editor", async () => {
+        const caller = callerWith({
+            selectRows: [[{ role: "Editor" }]],
+            insertRows: [{ id: 42, petId: 7, url: PHOTO_URL }],
+        });
+        const row = await caller.photos.add({ petId: 7, url: PHOTO_URL });
+        expect((row as { id: number }).id).toBe(42);
+    });
+
+    it("remove returns NOT_FOUND when the photo is missing", async () => {
+        const caller = callerWith({ selectRows: [[]] });
+        await expect(
+            caller.photos.remove({ photoId: 9999 }),
+        ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    });
+
+    it("remove rejects Viewer role", async () => {
+        const caller = callerWith({
+            selectRows: [
+                // loadPhoto
+                [{ id: 5, petId: 7, url: PHOTO_URL }],
+                // assertPetAccess
+                [{ role: "Viewer" }],
+            ],
+        });
+        await expect(
+            caller.photos.remove({ photoId: 5 }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("remove succeeds for Editor", async () => {
+        const caller = callerWith({
+            selectRows: [
+                [{ id: 5, petId: 7, url: PHOTO_URL }],
+                [{ role: "Editor" }],
+            ],
+        });
+        const result = await caller.photos.remove({ photoId: 5 });
+        expect(result).toEqual({ ok: true });
+    });
+
+    it("setPrimary rejects Viewer role", async () => {
+        const caller = callerWith({
+            selectRows: [
+                [{ id: 5, petId: 7, url: PHOTO_URL }],
+                [{ role: "Viewer" }],
+            ],
+        });
+        await expect(
+            caller.photos.setPrimary({ photoId: 5 }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("setPrimary succeeds for Editor", async () => {
+        const caller = callerWith({
+            selectRows: [
+                [{ id: 5, petId: 7, url: PHOTO_URL }],
+                [{ role: "Editor" }],
+            ],
+        });
+        const result = await caller.photos.setPrimary({ photoId: 5 });
+        expect(result).toEqual({ ok: true });
+    });
+});

--- a/src/server/api/routers/__tests__/timeline-router.test.ts
+++ b/src/server/api/routers/__tests__/timeline-router.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import { createCaller } from "~/server/api/root";
+import { makeStubDb, type StubScenario } from "./mock-db";
+
+function callerWith(scenario: StubScenario, userId = "u_1") {
+    const db = makeStubDb(scenario);
+    return createCaller({ db, userId, headers: new Headers() });
+}
+
+// timeline.get consumes selectRows in this order: assertPetAccess, then the
+// Promise.all of weights, feedings, activities, health events, notes.
+
+describe("timeline router", () => {
+    it("get rejects when the user has no access", async () => {
+        const caller = callerWith({ selectRows: [[]] });
+        await expect(
+            caller.timeline.get({ petId: 7 }),
+        ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    });
+
+    it("get returns an empty timeline when there is no history", async () => {
+        const caller = callerWith({
+            selectRows: [[{ role: "Viewer" }], [], [], [], [], []],
+        });
+        const items = await caller.timeline.get({ petId: 7 });
+        expect(items).toEqual([]);
+    });
+
+    it("get merges all five history kinds, newest first", async () => {
+        const caller = callerWith({
+            selectRows: [
+                [{ role: "Viewer" }],
+                // weights — 2026-01-01
+                [{ id: 1, weighedAt: new Date("2026-01-01"), weight: 4.2 }],
+                // feedings — 2026-01-02
+                [
+                    {
+                        id: 2,
+                        fedAt: new Date("2026-01-02"),
+                        quantityGrams: 50,
+                        foodName: "Tuna",
+                    },
+                ],
+                // activities — 2026-01-03
+                [
+                    {
+                        id: 3,
+                        performedAt: new Date("2026-01-03"),
+                        activityType: "Play",
+                        durationMinutes: 15,
+                        notes: null,
+                    },
+                ],
+                // health events — 2026-01-04
+                [
+                    {
+                        id: 4,
+                        occurredAt: new Date("2026-01-04"),
+                        eventType: "Vet visit",
+                        title: "Checkup",
+                        notes: null,
+                    },
+                ],
+                // notes — 2026-01-05
+                [
+                    {
+                        id: 5,
+                        writtenAt: new Date("2026-01-05"),
+                        body: "Good day",
+                    },
+                ],
+            ],
+        });
+        const items = await caller.timeline.get({ petId: 7 });
+        expect(items.map((i) => i.kind)).toEqual([
+            "note",
+            "health",
+            "activity",
+            "feeding",
+            "weight",
+        ]);
+    });
+
+    it("get sorts by date even when sources arrive out of order", async () => {
+        const caller = callerWith({
+            selectRows: [
+                [{ role: "Editor" }],
+                // weight — oldest
+                [{ id: 1, weighedAt: new Date("2026-01-01"), weight: 4.2 }],
+                // feeding — newest
+                [
+                    {
+                        id: 2,
+                        fedAt: new Date("2026-03-01"),
+                        quantityGrams: 50,
+                        foodName: "Tuna",
+                    },
+                ],
+                [],
+                [],
+                // note — middle
+                [{ id: 3, writtenAt: new Date("2026-02-01"), body: "Hi" }],
+            ],
+        });
+        const items = await caller.timeline.get({ petId: 7 });
+        expect(items.map((i) => i.kind)).toEqual([
+            "feeding",
+            "note",
+            "weight",
+        ]);
+    });
+
+    it("get maps kind-specific fields onto each item", async () => {
+        const caller = callerWith({
+            selectRows: [
+                [{ role: "Viewer" }],
+                [{ id: 1, weighedAt: new Date("2026-01-01"), weight: 4.2 }],
+                [
+                    {
+                        id: 2,
+                        fedAt: new Date("2026-01-02"),
+                        quantityGrams: 50,
+                        foodName: "Tuna",
+                    },
+                ],
+                [],
+                [],
+                [],
+            ],
+        });
+        const items = await caller.timeline.get({ petId: 7 });
+        const weight = items.find((i) => i.kind === "weight");
+        const feeding = items.find((i) => i.kind === "feeding");
+        expect(weight).toMatchObject({ kind: "weight", id: 1, weightKg: 4.2 });
+        expect(feeding).toMatchObject({
+            kind: "feeding",
+            id: 2,
+            foodName: "Tuna",
+            quantityGrams: 50,
+        });
+    });
+});

--- a/src/server/api/routers/appointments.ts
+++ b/src/server/api/routers/appointments.ts
@@ -11,6 +11,7 @@ import {
     updateAppointmentInput,
 } from "~/schema/updateAppointmentInput";
 import { assertPetAccess } from "~/server/api/petAccess";
+import { enforceRateLimit } from "~/server/api/ratelimit";
 
 async function loadAppointmentPetId(
     database: typeof db,
@@ -45,6 +46,12 @@ export const appointmentsRouter = createTRPCRouter({
     create: protectedProcedure
         .input(createAppointmentInput)
         .mutation(async ({ ctx, input }) => {
+            await enforceRateLimit(
+                "createAppointment",
+                ctx.userId,
+                20,
+                "1 h",
+            );
             const role = await assertPetAccess(
                 ctx.db,
                 ctx.userId,

--- a/src/server/api/routers/photos.ts
+++ b/src/server/api/routers/photos.ts
@@ -1,7 +1,9 @@
 import { and, desc, eq } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
+import { del } from "@vercel/blob";
 import { z } from "zod";
 
+import { env } from "~/env";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { type db } from "~/server/db";
 import { petPhotos, pets } from "~/server/db/schema";
@@ -84,6 +86,22 @@ export const photosRouter = createTRPCRouter({
                         eq(pets.photoUrl, photo.url),
                     ),
                 );
+            // Best-effort: drop the underlying Blob object so removed
+            // photos don't linger in storage. A failure here (missing
+            // token, an already-gone object, a non-Blob url) must not
+            // fail the mutation — the DB row is already deleted.
+            if (env.BLOB_READ_WRITE_TOKEN) {
+                try {
+                    await del(photo.url, {
+                        token: env.BLOB_READ_WRITE_TOKEN,
+                    });
+                } catch (err) {
+                    console.error(
+                        `Failed to delete blob for photo ${photo.id}`,
+                        err,
+                    );
+                }
+            }
             return { ok: true as const };
         }),
 

--- a/src/server/api/routers/photos.ts
+++ b/src/server/api/routers/photos.ts
@@ -9,6 +9,7 @@ import { type db } from "~/server/db";
 import { petPhotos, pets } from "~/server/db/schema";
 import { addPetPhotoInput } from "~/schema/addPetPhotoInput";
 import { assertPetAccess } from "~/server/api/petAccess";
+import { enforceRateLimit } from "~/server/api/ratelimit";
 
 async function loadPhoto(database: typeof db, photoId: number) {
     const [row] = await database
@@ -40,6 +41,7 @@ export const photosRouter = createTRPCRouter({
     add: protectedProcedure
         .input(addPetPhotoInput)
         .mutation(async ({ ctx, input }) => {
+            await enforceRateLimit("addPhoto", ctx.userId, 60, "1 h");
             const role = await assertPetAccess(ctx.db, ctx.userId, input.petId);
             if (role === "Viewer") {
                 throw new TRPCError({

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -14,10 +14,14 @@ test.describe("landing page", () => {
         page,
     }) => {
         const response = await page.goto("/dashboard");
-        // Clerk's middleware redirects unauthenticated users to /sign-in.
-        // We assert the final URL is somewhere on the auth flow and the
-        // page rendered without crashing.
-        expect(response?.ok()).toBe(true);
-        await expect(page).toHaveURL(/\/(sign-in|$)/);
+        // Anonymous users must not reach the dashboard. Depending on the
+        // Clerk configuration this is either a redirect into the sign-in
+        // flow or a blocked (non-OK) response — both count as "protected".
+        // A fixed 200-redirect assertion fails under CI's dummy Clerk keys,
+        // where auth().protect() returns a 404 instead of redirecting.
+        const reachedDashboard =
+            /\/dashboard(\/|$)/.test(page.url()) &&
+            (response?.ok() ?? false);
+        expect(reachedDashboard).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary

Batch 8 — quality & hardening, stacked on the Batch 7 tip (`claude/a11y-pass` @ S71). Nine stories, one commit each, paying down debt from the prior batches:

- **S72 — fix the broken e2e test.** The `dashboard route is protected` test required `/dashboard` to be a 200 redirect, but under CI's dummy Clerk keys `auth().protect()` returns a 404 — so the `checks` job had been red since Batch 6. Now asserts the environment-agnostic invariant: an anonymous user never *reaches* the dashboard. **This should turn CI green again.**
- **S73 — `photos` router tests.** 10 tests across list/add/remove/setPrimary (happy paths, no-access, Viewer-rejected, NOT_FOUND, invalid-URL input).
- **S74 — `appointments` router tests.** 13 tests across list/create/updateEntry/setStatus/deleteEntry.
- **S75 — `timeline` router tests.** 5 tests: access control, empty timeline, the five-source merge, date sorting, and kind-specific field mapping.
- **S76 — escape user content in cron emails.** The feeding reminder interpolated `pet.name` straight into email HTML; now routed through the existing `escapeHtml` helper (matching the appointment emails from S67).
- **S77 — Blob cleanup on photo removal.** `photos.remove` deleted the DB row but orphaned the Vercel Blob file; it now also `del()`s the blob (best-effort — guarded on the token, failures logged, never fails the mutation).
- **S78 — rate-limit the new creation mutations.** `photos.add` and `appointments.create` now use `enforceRateLimit`, matching how `insertPet` / `createInvite` / `recordWeight` are guarded. Update/delete/status mutations left unlimited, consistent with the existing routers.
- **S79 — skeleton loading states.** Replaced plain "Loading…" text with a shared, accessible `ListSkeleton` (`role="status"` + sr-only label) across all ~10 pet-detail list cards — the Batch 7 cards plus the pre-existing health/notes/meds/weight/feeding/people/foods cards. Photo gallery gets a matching grid of square skeletons.
- **S80 — daily-reminders cron tests.** 5 tests covering the `CRON_SECRET` auth guard, the no-op when Resend isn't configured, and a configured run with no pets — with env/db/Resend/clerkClient mocked.

Net: **+33 unit tests** (76 → 109), and the cron + photo routers are now covered. No schema changes, so no new migrations.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 109/109 passing (18 files)
- [x] `pnpm build` — succeeds
- [x] Drizzle drift check — no uncommitted schema changes
- [ ] Playwright e2e — **not runnable in this environment** (browser download blocked). S72's fix is verified against the reproduced behavior (`/dashboard` 404s under dummy Clerk keys → the new assertion passes), but the actual runner should be confirmed by CI / a human.
- [ ] Manual QA of S79: confirm the skeleton loaders look right on the pet-detail page and the foods/people pages.

https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVWfwctyfuoHjtgFHhLnUg)_