### PR TITLE
infra(infra-0001): homelab containerization (dual-pipeline mirror)

### DIFF
--- a/.deploy-target
+++ b/.deploy-target
@@ -1,0 +1,4 @@
+dev:
+  app: meow-weight-tracker-dev
+prod:
+  app: meow-weight-tracker-prod

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+.next
+.git
+.gitignore
+.github
+.vercel
+.idea
+.vscode
+.DS_Store
+*.log
+coverage
+playwright-report
+test-results
+.env*
+!.env.example
+README.md
+docs/

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,0 +1,148 @@
+# Woodpecker CI for meow-weight-tracker.
+#
+# Pipeline shape (matches docs/homelab-migration-plan.md § Phase 4 and the
+# canonical pattern in homelab_infra_and_planning/docs/cicd-flow.md):
+#
+#   Event           Steps that fire
+#   ─────────────── ──────────────────────────────────────────────────────
+#   pull_request    check, publish-pr
+#   push → main     check, publish-main, deploy-dev
+#   tag v*          check, publish-tag, deploy-prod
+#
+# Secrets (registered globally by the homelab woodpecker-setup.yml
+# _wp_secrets loop; pulled into steps via environment.VAR.from_secret):
+#   registry_user                          — Gitea user, plaintext
+#   registry_token                         — Gitea token with write:package
+#   meow_weight_tracker_dev_db_url         — POSTGRES_URL for CI tests (optional, tests are pure)
+#   dokploy_token                          — Dokploy PAT (x-api-key)
+#   meow_weight_tracker_{dev,prod}_app_id  — Dokploy application IDs
+#
+# .github/workflows/ci.yml continues to run on the github remote — dual
+# pipeline doctrine (see homelab project_dual_pipeline memory).
+
+when:
+  - event: [pull_request, push, tag]
+
+steps:
+  # ── Node test gates: pnpm + lint + typecheck + test + build ─────────
+  # No sidecar DB — meow's vitest suite is pure unit (src/lib/*.test.ts).
+  # SKIP_ENV_VALIDATION lets the env validator no-op during the build
+  # step (POSTGRES_URL etc. are runtime concerns).
+  check:
+    image: node:22-alpine
+    environment:
+      SKIP_ENV_VALIDATION: "1"
+      NEXT_TELEMETRY_DISABLED: "1"
+    commands:
+      - corepack enable pnpm
+      - pnpm install --frozen-lockfile
+      - pnpm run lint
+      - pnpm run typecheck
+      - pnpm test
+      - pnpm run build
+
+  # ── Image publishing ───────────────────────────────────────────────
+  # Build the Dockerfile's `runtime` target and push to git.lab registry.
+  # The agent mounts /etc/docker/certs.d so buildkitd auto-detects the
+  # Caddy CA and pushes under proper TLS. NEXT_PUBLIC_* env vars get
+  # baked into the JS bundle at build; supply via build_args once secrets
+  # are minted (see homelab `_wp_secrets`).
+
+  publish-pr:
+    image: woodpeckerci/plugin-docker-buildx:latest
+    settings:
+      registry: git.lab
+      repo: git.lab/nick-b/meow-weight-tracker
+      dockerfile: Dockerfile
+      target: runtime
+      username:
+        from_secret: registry_user
+      password:
+        from_secret: registry_token
+      tags:
+        - "pr-${CI_COMMIT_PULL_REQUEST}-${CI_COMMIT_SHA:0:8}"
+        - "pr-${CI_COMMIT_PULL_REQUEST}-latest"
+    when:
+      - event: pull_request
+    depends_on:
+      - check
+
+  publish-main:
+    image: woodpeckerci/plugin-docker-buildx:latest
+    settings:
+      registry: git.lab
+      repo: git.lab/nick-b/meow-weight-tracker
+      dockerfile: Dockerfile
+      target: runtime
+      username:
+        from_secret: registry_user
+      password:
+        from_secret: registry_token
+      tags:
+        - "main-${CI_COMMIT_SHA:0:8}"
+        - "dev-latest"
+    when:
+      - event: push
+        branch: main
+    depends_on:
+      - check
+
+  publish-tag:
+    image: woodpeckerci/plugin-docker-buildx:latest
+    settings:
+      registry: git.lab
+      repo: git.lab/nick-b/meow-weight-tracker
+      dockerfile: Dockerfile
+      target: runtime
+      username:
+        from_secret: registry_user
+      password:
+        from_secret: registry_token
+      tags:
+        - "${CI_COMMIT_TAG}"
+        - "${CI_COMMIT_SHA:0:8}"
+        - "prod-latest"
+    when:
+      - event: tag
+    depends_on:
+      - check
+
+  # ── Dokploy redeploy hooks (x-api-key + tRPC route) ──────────────────
+  deploy-dev:
+    image: curlimages/curl:8.10.1
+    environment:
+      DOKPLOY_TOKEN:
+        from_secret: dokploy_token
+      DOKPLOY_APP_ID:
+        from_secret: meow_weight_tracker_dev_app_id
+    commands:
+      - >-
+        curl -fsSL --cacert /etc/ssl/certs/ca-certificates.crt -X POST
+        -H "x-api-key: $${DOKPLOY_TOKEN}"
+        -H "Content-Type: application/json"
+        -d "{\"applicationId\":\"$${DOKPLOY_APP_ID}\"}"
+        https://dokploy.lab/api/application.deploy
+    when:
+      - event: push
+        branch: main
+    depends_on:
+      - publish-main
+
+  deploy-prod:
+    image: curlimages/curl:8.10.1
+    environment:
+      DOKPLOY_TOKEN:
+        from_secret: dokploy_token
+      DOKPLOY_APP_ID:
+        from_secret: meow_weight_tracker_prod_app_id
+    commands:
+      - >-
+        curl -fsSL --cacert /etc/ssl/certs/ca-certificates.crt -X POST
+        -H "x-api-key: $${DOKPLOY_TOKEN}"
+        -H "Content-Type: application/json"
+        -d "{\"applicationId\":\"$${DOKPLOY_APP_ID}\"}"
+        https://dokploy.lab/api/application.deploy
+    when:
+      - event: tag
+    depends_on:
+      - publish-tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,95 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage image for meow-weight-tracker (Next.js 14, standalone output).
+#
+# Reference: scripts/templates/woodpecker-app/node-fullstack/Dockerfile in the
+# homelab repo; customised for Next.js' standalone runtime payload + pnpm.
+
+ARG NODE_VERSION=22
+
+# ============================================================
+# Stage 1 — Resolve deps via pnpm (cached unless package.json/lockfile change)
+# ============================================================
+FROM node:${NODE_VERSION}-alpine AS deps
+WORKDIR /app
+RUN apk add --no-cache libc6-compat python3 make g++
+RUN corepack enable pnpm
+COPY package.json pnpm-lock.yaml ./
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
+
+# ============================================================
+# Stage 2 — Build Next.js (standalone output + static assets)
+# ============================================================
+FROM node:${NODE_VERSION}-alpine AS builder
+WORKDIR /app
+RUN corepack enable pnpm
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# NEXT_PUBLIC_* env vars are statically baked into the JS bundle at build
+# time. Supply per-env values via Woodpecker --build-arg in .woodpecker.yml.
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=""
+ARG NEXT_PUBLIC_SENTRY_DSN=""
+ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY} \
+    NEXT_PUBLIC_SENTRY_DSN=${NEXT_PUBLIC_SENTRY_DSN}
+
+# The env validator in src/env.js asserts POSTGRES_URL.url() at build —
+# skip so the build doesn't need the runtime DB URL.
+ENV SKIP_ENV_VALIDATION=1
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN pnpm build
+
+# ============================================================
+# Stage 3 — Runtime (Next.js standalone server.js)
+# ============================================================
+FROM node:${NODE_VERSION}-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+RUN addgroup -S -g 1001 nodejs && adduser -S -u 1001 -G nodejs nextjs
+
+# Standalone bundle (server.js + minimal node_modules tree)
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+# Migration assets — entrypoint runs Drizzle migrations before exec'ing server.
+# The standalone trace doesn't pick up drizzle-orm/postgres CLI deps because
+# nothing in the runtime bundle imports them; copy explicitly.
+COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/drizzle-orm ./node_modules/drizzle-orm
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/postgres ./node_modules/postgres
+COPY --from=builder --chown=nextjs:nodejs /app/scripts/run-migrations.mjs ./scripts/run-migrations.mjs
+COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+USER nextjs
+EXPOSE 3000
+HEALTHCHECK --interval=10s --timeout=5s --start-period=20s --retries=3 \
+    CMD wget -q --spider http://127.0.0.1:3000/ || exit 1
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["node", "server.js"]
+
+# ============================================================
+# Stage 4 — Dev (Dokploy dev slot, full deps + next dev)
+# ============================================================
+FROM node:${NODE_VERSION}-alpine AS dev
+WORKDIR /app
+ENV NODE_ENV=development \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+RUN apk add --no-cache libc6-compat python3 make g++
+RUN corepack enable pnpm
+COPY package.json pnpm-lock.yaml ./
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
+COPY . .
+COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+EXPOSE 3000
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["pnpm", "dev"]

--- a/next.config.js
+++ b/next.config.js
@@ -6,8 +6,11 @@ await import("./src/env.js");
 
 /** @type {import("next").NextConfig} */
 const config = {
-  // @vercel/blob v2 bundles undici, which ships private-class-field syntax that
-  // Next 14's webpack loader can't parse. Keep it as a runtime Node import.
+  // Required for the homelab container image: produces a self-contained
+  // `.next/standalone/server.js` runtime payload that the Dockerfile copies
+  // directly. Without this, the runtime stage would need the full repo +
+  // node_modules.
+  output: "standalone",
   experimental: {
     serverComponentsExternalPackages: ["@vercel/blob"],
   },

--- a/scripts/ci-precheck.sh
+++ b/scripts/ci-precheck.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# ci-precheck: fast local sanity for the CI definition.
+#
+# Catches the 1-second-fixable problems that otherwise burn a 7-minute
+# Woodpecker cycle: malformed YAML, deprecated v2 step syntax, plugin
+# image typos, references to secrets the Woodpecker server doesn't have.
+#
+# Designed to be runnable in <2 seconds locally before you push. Lifts
+# the validation loop from "wait for the pipeline" to "wait for sed."
+# Postmortem (homelab docs/incidents/009) § P3 is the reason this
+# exists.
+#
+# Usage:
+#   make ci-precheck                       # default
+#   ./scripts/ci-precheck.sh
+#
+# Env overrides:
+#   WP_URL                  Woodpecker base URL (default https://ci.lab)
+#   WP_TOKEN                Woodpecker PAT for /api/secrets probe (optional)
+#                           — without it the secret-existence check skips.
+#   YAML_FILE               Override the woodpecker file (default
+#                           .woodpecker.yml).
+
+set -uo pipefail
+
+YAML_FILE="${YAML_FILE:-.woodpecker.yml}"
+WP_URL="${WP_URL:-https://ci.lab}"
+WP_TOKEN="${WP_TOKEN:-}"
+
+PASS=0
+FAIL=0
+
+red()  { printf '\033[0;31m%s\033[0m' "$*"; }
+grn()  { printf '\033[0;32m%s\033[0m' "$*"; }
+ylw()  { printf '\033[0;33m%s\033[0m' "$*"; }
+
+ok()   { PASS=$((PASS+1)); printf '  %s %s\n' "$(grn '✓')" "$*"; }
+bad()  { FAIL=$((FAIL+1)); printf '  %s %s\n' "$(red '✗')" "$*"; }
+skip() {              printf '  %s %s\n' "$(ylw '○')" "$*"; }
+
+# --- 1. File present + YAML parses ---
+echo "$(grn parse:)"
+if [[ ! -f "$YAML_FILE" ]]; then
+    bad "$YAML_FILE not found"
+    exit 1
+fi
+if ! uv run --quiet --with pyyaml python -c "import yaml,sys; yaml.safe_load(open('$YAML_FILE'))" 2>/dev/null; then
+    bad "$YAML_FILE is not valid YAML"
+    uv run --quiet --with pyyaml python -c "import yaml; yaml.safe_load(open('$YAML_FILE'))" 2>&1 | sed 's/^/    /'
+    exit 1
+fi
+ok "$YAML_FILE parses as YAML"
+
+# --- 2. v2 syntax regressions ---
+echo "$(grn syntax:)"
+# Bare `secrets: [...]` on a step is v2-only — Woodpecker 3 rejects.
+if grep -nE '^[[:space:]]*secrets:[[:space:]]*\[' "$YAML_FILE" >/dev/null 2>&1; then
+    bad "step uses v2 \`secrets: [...]\` syntax — Woodpecker 3 wants \`environment.VAR.from_secret\`"
+    grep -nE '^[[:space:]]*secrets:[[:space:]]*\[' "$YAML_FILE" | sed 's/^/    /'
+else
+    ok "no v2 \`secrets: […]\` step syntax"
+fi
+# Bare list under `secrets:` block (multi-line v2 form).
+if uv run --quiet --with pyyaml python -c "
+import yaml,sys
+d = yaml.safe_load(open('$YAML_FILE'))
+bad = []
+for name, step in (d.get('steps') or {}).items():
+    if isinstance(step, dict) and isinstance(step.get('secrets'), list):
+        bad.append(name)
+sys.exit(1 if bad else 0)
+print(','.join(bad))
+" 2>/dev/null; then
+    ok "no v2 \`secrets:\` list under any step"
+else
+    bad "v2 \`secrets:\` list found under: $(uv run --quiet --with pyyaml python -c "
+import yaml
+d = yaml.safe_load(open('$YAML_FILE'))
+print(','.join(n for n,s in (d.get('steps') or {}).items() if isinstance(s, dict) and isinstance(s.get('secrets'), list)))
+")"
+fi
+
+# --- 3. Plugin image freshness ---
+echo "$(grn images:)"
+if grep -nE 'image:[[:space:]]*woodpeckerci/plugin-docker:' "$YAML_FILE" >/dev/null 2>&1; then
+    bad "uses deprecated woodpeckerci/plugin-docker (use plugin-docker-buildx)"
+else
+    ok "no deprecated woodpeckerci/plugin-docker references"
+fi
+
+# --- 4. Secret references actually exist (best-effort, needs WP_TOKEN) ---
+echo "$(grn secrets:)"
+SECRETS_REFERENCED=$(uv run --quiet --with pyyaml python -c "
+import yaml, sys, json
+d = yaml.safe_load(open('$YAML_FILE'))
+seen = set()
+def walk(node):
+    if isinstance(node, dict):
+        if 'from_secret' in node and isinstance(node['from_secret'], str):
+            seen.add(node['from_secret'])
+        for v in node.values(): walk(v)
+    elif isinstance(node, list):
+        for v in node: walk(v)
+walk(d)
+print('\n'.join(sorted(seen)))
+")
+if [[ -z "$WP_TOKEN" ]]; then
+    skip "WP_TOKEN unset — skipping live secret-existence probe"
+    if [[ -n "$SECRETS_REFERENCED" ]]; then
+        echo "    secrets referenced: $(echo "$SECRETS_REFERENCED" | tr '\n' ' ')"
+    fi
+else
+    HAVE=$(curl -fsSL -H "Authorization: Bearer $WP_TOKEN" "$WP_URL/api/secrets" 2>/dev/null \
+            | uv run --quiet --with pyyaml python -c "import json,sys;[print(s['name']) for s in json.load(sys.stdin)]" 2>/dev/null \
+            | sort -u)
+    MISSING=""
+    for name in $SECRETS_REFERENCED; do
+        if ! echo "$HAVE" | grep -qx "$name"; then
+            MISSING="$MISSING $name"
+        fi
+    done
+    if [[ -n "$MISSING" ]]; then
+        bad "secrets referenced in $YAML_FILE but absent from Woodpecker:$MISSING"
+    else
+        ok "all $(echo "$SECRETS_REFERENCED" | wc -l | tr -d ' ') referenced secrets exist on $WP_URL"
+    fi
+fi
+
+# --- 5. .deploy-target shape (optional) ---
+echo "$(grn deploy-target:)"
+if [[ -f ".deploy-target" ]]; then
+    if uv run --quiet --with pyyaml python -c "
+import yaml, sys
+d = yaml.safe_load(open('.deploy-target')) or {}
+errs = []
+for env, cfg in d.items():
+    if not isinstance(cfg, dict):
+        errs.append(f'{env}: not a dict')
+        continue
+    if 'app' in cfg and 'apps' in cfg:
+        errs.append(f'{env}: has both \`app\` and \`apps\` (pick one)')
+    if 'app' not in cfg and 'apps' not in cfg:
+        errs.append(f'{env}: missing \`app\` or \`apps\`')
+sys.exit(0 if not errs else 1)
+"; then
+        ok ".deploy-target shape OK"
+    else
+        bad ".deploy-target malformed"
+    fi
+else
+    skip "no .deploy-target (not all apps need one)"
+fi
+
+# --- summary ---
+echo
+if (( FAIL == 0 )); then
+    printf '%s  %d checks passed\n' "$(grn 'PRECHECK PASS:')" "$PASS"
+    exit 0
+else
+    printf '%s  %d failed / %d total\n' "$(red 'PRECHECK FAIL:')" "$FAIL" "$((PASS+FAIL))"
+    exit 1
+fi

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# Container entrypoint: run Drizzle migrations idempotently, then exec the
+# CMD (next.js standalone server.js by default).
+#
+# Migration failure exits non-zero so Dokploy reports a failed deploy instead
+# of a healthy-but-broken container. Matches the swe-interview-prep pattern.
+
+set -eu
+
+if [ -z "${POSTGRES_URL:-}" ]; then
+    echo "FATAL: POSTGRES_URL is not set." >&2
+    exit 1
+fi
+
+echo "[entrypoint] running drizzle migrations"
+node ./scripts/run-migrations.mjs
+
+echo "[entrypoint] exec: $*"
+exec "$@"

--- a/scripts/run-migrations.mjs
+++ b/scripts/run-migrations.mjs
@@ -1,0 +1,20 @@
+// Drizzle migration runner — invoked from docker-entrypoint.sh on container
+// boot. Equivalent to `drizzle-kit migrate` but doesn't require drizzle-kit
+// (a devDependency, not present in the standalone runtime image).
+
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import postgres from "postgres";
+
+const url = process.env.POSTGRES_URL;
+if (!url) {
+  console.error("FATAL: POSTGRES_URL is not set.");
+  process.exit(1);
+}
+
+const client = postgres(url, { max: 1 });
+const db = drizzle(client);
+
+await migrate(db, { migrationsFolder: "./drizzle" });
+await client.end();
+console.log("[migrate] done");

--- a/scripts/smoke-deployed.sh
+++ b/scripts/smoke-deployed.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Curl-based smoke test for a deployed meow-weight-tracker slot.
+#
+# Hits substrate (healthz when implemented), the marketing/home page,
+# and the protected /dashboard route (expects redirect to Clerk sign-in).
+#
+# Usage:
+#   scripts/smoke-deployed.sh                                  # default: dev
+#   TARGET=https://meow-weight-tracker.app.lab scripts/smoke-deployed.sh
+
+set -uo pipefail
+
+TARGET="${TARGET:-https://meow-weight-tracker-dev.app.lab}"
+PASS=0
+FAIL=0
+
+red() { printf '\033[0;31m%s\033[0m' "$*"; }
+grn() { printf '\033[0;32m%s\033[0m' "$*"; }
+
+ok()  { PASS=$((PASS+1)); printf '  %s %s\n' "$(grn '✓')" "$*"; }
+bad() { FAIL=$((FAIL+1)); printf '  %s %s\n' "$(red '✗')" "$*"; }
+
+require_status() {
+    local url="$1" want="$2" label="$3"
+    local got
+    got=$(curl -sS -o /dev/null -w "%{http_code}" -m 10 "$url" 2>/dev/null || echo "000")
+    if [[ "$got" == "$want" ]]; then
+        ok "$label  ($want)"
+    else
+        bad "$label  (want $want, got $got)  url=$url"
+    fi
+}
+
+require_status_in() {
+    local url="$1" want_csv="$2" label="$3"
+    local got
+    got=$(curl -sS -o /dev/null -w "%{http_code}" -m 10 "$url" 2>/dev/null || echo "000")
+    if [[ ",$want_csv," == *",$got,"* ]]; then
+        ok "$label  ($got)"
+    else
+        bad "$label  (want one of $want_csv, got $got)  url=$url"
+    fi
+}
+
+echo "TARGET=$TARGET"
+echo
+
+# 1. Root / home page — public, should 200
+require_status "$TARGET/"                          "200"      "GET /"
+# 2. /dashboard — Clerk-protected; accepts 200 (Clerk renders sign-in inline)
+#    OR 307/302 (Clerk redirect to /sign-in).
+require_status_in "$TARGET/dashboard"              "200,302,307" "GET /dashboard (clerk-protected)"
+# 3. _next/static asset path — Next.js serves these directly
+require_status_in "$TARGET/_next/static/css"       "404,403"  "GET /_next/static/css (no such file but path serves)"
+# 4. Favicon
+require_status_in "$TARGET/favicon.ico"            "200,404"  "GET /favicon.ico"
+
+echo
+if (( FAIL == 0 )); then
+    printf '%s  %d checks passed\n' "$(grn 'SMOKE PASS:')" "$PASS"
+    exit 0
+else
+    printf '%s  %d failed / %d total\n' "$(red 'SMOKE FAIL:')" "$FAIL" "$((PASS+FAIL))"
+    exit 1
+fi

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -1,7 +1,8 @@
-import { drizzle } from 'drizzle-orm/vercel-postgres';
-import { sql } from '@vercel/postgres'
-import * as schema from "./schema"
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { env } from "~/env";
+import * as schema from "./schema";
 
-// Use this object to send drizzle queries to your DB
-export const db = drizzle(sql, { schema });
-// Create a pgTable that maps to a table in your DB
+const client = postgres(env.POSTGRES_URL, { max: 1 });
+
+export const db = drizzle(client, { schema });


### PR DESCRIPTION
## Summary
Mirror of the Gitea PR https://git.bittern-chameleon.dev/nick-b/meow-weight-tracker/pulls/1.

Adds homelab CI/CD scaffolding (Dockerfile, .woodpecker.yml, smoke + precheck) plus two source changes the homelab deploy needs:

- `src/server/db/index.ts`: swap `@vercel/postgres` → `postgres-js` (NAS Postgres can't speak Neon's HTTP).
- `next.config.js`: add `output: "standalone"` for the runtime image.

Per the dual-pipeline doctrine, GitHub Actions ci.yml stays live — this side runs lint/typecheck/test/build only; Gitea/Woodpecker handles publish + deploy.

## Test plan
- [ ] GHA `checks` workflow green on this branch
- [ ] Woodpecker pipeline green on Gitea side
- [ ] `docker build --target runtime` succeeds locally (verified)